### PR TITLE
trio support, code cleanup and pytest changes

### DIFF
--- a/cyares/channel.pyi
+++ b/cyares/channel.pyi
@@ -33,7 +33,7 @@ QUERY_CLASS_NONE: int = ...
 QUERY_CLASS_ANY: int = ...
 
 class Channel:
-    event_thread:bool
+    event_thread: bool
     """Used for checking if event-thread is in use before using wait(...)
     This is good for when you plan to make event-thread optional in a user 
     program
@@ -319,15 +319,15 @@ class Channel:
     def timeout(self, t: float = ...) -> float: ...
     def wait(self, timeout: float | int | None = None) -> bool:
         """Waits for all queries to close using `ares_queue_wait_emtpy`
-        This function blocks until notified that the timeout expired or 
-        that all pending queries have been cancelled or completed. 
+        This function blocks until notified that the timeout expired or
+        that all pending queries have been cancelled or completed.
 
         Parameters
         ----------
 
         :param timeout: A timeout in seconds as a float or integer object
-            this object will be rounded to milliseconds, throws `TypeError` 
-            if object is not None or an `int` or `float` other wise it throws 
+            this object will be rounded to milliseconds, throws `TypeError`
+            if object is not None or an `int` or `float` other wise it throws
             `ValueError` if the timeout is less than 0, default runs until
             all cancelled or closed
 

--- a/cyares/socket_handle.pxd
+++ b/cyares/socket_handle.pxd
@@ -1,30 +1,13 @@
-
-# This Objects works simillar to a future except that 
-# it's called from multiple times...
-# from threading import Condition as _Condition
-
 from .ares cimport ares_socket_t
-
-# cdef Condition = _Condition
-
-# cdef enum SocketHandleState:
-#     STATE_RUNNING = 0,
-#     STATE_CANCELLED = 1
 
 
 cdef class SocketHandle:
     cdef:
         object callback
-        # SocketHandleState state
-        # object _cond
-    
+
     @staticmethod
     cdef SocketHandle new(object callback)
 
-    # cdef bint check_state(self, SocketHandleState state)
-    # cdef bint running(self)
-    # cdef bint cancelled(self)
-    # cdef void cancel(self)
     cdef void handle_cb(self, ares_socket_t socket_fd, int readable, int writable) noexcept
     
 

--- a/cyares/socket_handle.pyx
+++ b/cyares/socket_handle.pyx
@@ -2,36 +2,14 @@ from cpython.bool cimport PyBool_FromLong
 
 from .ares cimport *
 
-from threading import Condition
-
 
 cdef class SocketHandle:
     
     @staticmethod
     cdef SocketHandle new(object callback):
         cdef SocketHandle handle = SocketHandle.__new__(SocketHandle)
-        # handle.state = STATE_RUNNING 
-        # handle._cond = Condition()
         handle.callback = callback
         return handle
-
-    # cdef bint check_state(self, SocketHandleState state):
-    #     cdef bint ret
-    #     with self._cond:
-    #         ret = self.state == state
-    #     return ret
-    # 
-    # cdef bint running(self):
-    #     return self.check_state(STATE_RUNNING)
-
-    # cdef bint cancelled(self):
-    #     return self.check_state(STATE_CANCELLED)
-
-    # cdef void cancel(self):
-    #     with self._cond:
-    #         if self.state == STATE_CANCELLED:
-    #             return
-    #         self.state = STATE_CANCELLED
 
     cdef void handle_cb(self, ares_socket_t socket_fd, int readable, int writable) noexcept:
         try:

--- a/cyares/trio.py
+++ b/cyares/trio.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from concurrent.futures import Future as ccFuture
 from types import GenericAlias
 from typing import (

--- a/cyares/trio.py
+++ b/cyares/trio.py
@@ -1,0 +1,387 @@
+from concurrent.futures import Future as ccFuture
+from types import GenericAlias
+from typing import (
+    Callable,
+    Generic,
+    Iterable,
+    Optional,
+    Sequence,
+    TypeVar,
+    Literal,
+    overload,
+    Any,
+)
+
+import socket
+import trio
+from trio import Event
+from trio.lowlevel import (
+    checkpoint,
+    current_clock,
+    current_trio_token,
+    wait_readable,
+    wait_writable,
+)
+
+from .channel import *
+from .resulttypes import *
+
+
+class CancelledError(Exception):
+    pass
+
+
+class Timer:
+    def __init__(self, cb: Callable[..., None], timeout: Optional[float] = None):
+        self.clock = current_clock()
+        self.deadline = self.clock.current_time() + (timeout or 1)
+        self.cb = cb
+        self._running = False
+        self._close_event: Optional[trio.Event] = None
+
+    def _check_soon(self):
+        current_trio_token().run_sync_soon(self._check_time)
+
+    def _check_time(self):
+        if self._close_event:
+            # Timer was turned off by the end user to prepare for closure
+            return self._close_event.set()
+
+        if self.clock.current_time() >= self.deadline:
+            self.cb()
+            self._running = False
+        else:
+            self._check_soon()
+
+    def start(self):
+        self._running = True
+        self._check_soon()
+
+    def cancel(self):
+        if not self._close_event:
+            self._close_event = Event()
+
+    async def close(self) -> None:
+        """Waits for the timer to come to a callback where it can shut down"""
+        if not self._running:
+            # no need for an event just a heartbeat will be effective enough
+            return await checkpoint()
+
+        return await self._close_event.wait()
+
+
+query_type_map = {
+    "A": QUERY_TYPE_A,
+    "AAAA": QUERY_TYPE_AAAA,
+    "ANY": QUERY_TYPE_ANY,
+    "CAA": QUERY_TYPE_CAA,
+    "CNAME": QUERY_TYPE_CNAME,
+    "MX": QUERY_TYPE_MX,
+    "NAPTR": QUERY_TYPE_NAPTR,
+    "NS": QUERY_TYPE_NS,
+    "PTR": QUERY_TYPE_PTR,
+    "SOA": QUERY_TYPE_SOA,
+    "SRV": QUERY_TYPE_SRV,
+    "TXT": QUERY_TYPE_TXT,
+}
+
+query_class_map = {
+    "IN": QUERY_CLASS_IN,
+    "CHAOS": QUERY_CLASS_CHAOS,
+    "HS": QUERY_CLASS_HS,
+    "NONE": QUERY_CLASS_NONE,
+    "ANY": QUERY_CLASS_ANY,
+}
+
+_T = TypeVar("_T")
+
+
+class Future(Generic[_T]):
+    __class_getitem__ = classmethod(GenericAlias)
+
+    def __init__(self, fut: ccFuture[_T], uses_thread:bool = True):
+        self._exc = None
+        self._result = None
+        self._cancelled = False
+        self.event = Event()
+        self._callbacks: list[Callable[["Future[_T]"], None]] = []
+        # Token will allow use to reach the homethread allowing for a seamless transition
+        self._token = current_trio_token()
+        # all we needed the other future for was preparing to chain it.
+        fut.add_done_callback(self.__on_done)
+        # determines if were in the Home Thread 
+        self._uses_thread = uses_thread
+
+    def __execute_callbacks(self):
+        for cb in self._callbacks:
+            cb(self)
+        self._callbacks.clear()
+
+    def __handle_done(self):
+        self.event.set()
+        self.__execute_callbacks()
+
+    def __on_done(self, fut: ccFuture[_T]) -> None:
+        if fut.cancelled():
+            self._cancelled = True
+        elif exc := fut.exception():
+            self._exc = exc
+        else:
+            self._result = fut.result()
+
+        # We need to call everything else from the home-thread to prevent any errors...
+        if self._uses_thread:
+            trio.from_thread.run_sync(self.__handle_done, trio_token=self._token)
+        else:
+            self.__handle_done()
+
+    def done(self) -> bool:
+        return self.event.is_set()
+
+    def cancel(self):
+        if not self._cancelled and not self.done():
+            self._cancelled = True
+
+    def cancelled(self) -> bool:
+        return self.event.is_set() and self._cancelled
+
+    async def _wait(self) -> _T:
+        await self.event.wait()
+        if self._cancelled:
+            raise CancelledError()
+        elif self._exc:
+            raise self._exc
+        return self._result  # type: ignore
+
+    def __await__(self):
+        return self._wait().__await__()
+
+
+class DNSResolver:
+    # TODO: Use deprecated_params for socket_state_cb since it's handled manually
+    def __init__(
+        self,
+        servers: list[str] | None = None,
+        event_thread: bool = False, # turned off by default but you can always pass it if you wish...
+        **kw,
+    ):
+        kw.pop("socket_state_cb", None)
+
+        self._channel = Channel(
+            servers=servers,
+            event_thread=event_thread,
+            sock_state_cb=self._socket_state_cb if not event_thread else None,
+            **kw,
+        )
+        self._manager = trio.open_nursery()
+        self._nursery: Optional[trio.Nursery] = None
+        self._read_fds: set[int] = set()
+        self._write_fds: set[int] = set()
+        self._timeout = kw.get("timeout", None)
+        self._timer = None
+
+    async def __aenter__(self):
+        self._nursery = await self._manager.__aenter__()
+        return self
+
+    async def __aexit__(self, *args):
+        await self._manager.__aexit__(*args)
+
+    async def _handle_read(self, fd: int):
+        while fd in self._read_fds:
+            try:
+                await wait_readable(fd)
+                current_trio_token().run_sync_soon(self._channel.process_read_fd, fd)
+            except OSError:
+                if fd not in self._read_fds:
+                    break
+                raise
+
+    async def _handle_write(self, fd: int):
+        while fd in self._write_fds:
+            try:
+                await wait_writable(fd)
+                current_trio_token().run_sync_soon(self._channel.process_write_fd, fd)
+            except OSError:
+                if fd not in self._write_fds:
+                    break
+                raise
+
+    def _timer_cb(self) -> None:
+        if self._read_fds or self._write_fds:
+            self._channel.process_fd(CYARES_SOCKET_BAD, CYARES_SOCKET_BAD)
+            self._start_timer()
+        else:
+            timer = self._timer
+            # Timer Cleanup
+            self._nursery.start_soon(timer.close, name=f"Timer Cleanup: {self!r}")
+            self._timer = None
+
+    def _start_timer(self) -> None:
+        timeout = self._timeout
+        if timeout is None or timeout < 0 or timeout > 1:
+            timeout = 1
+        elif timeout == 0:
+            timeout = 0.1
+
+        self._timer = Timer(self._timer_cb, self._timeout)
+
+    def _socket_state_cb(self, fd: int, read: bool, write: bool) -> None:
+        if read or write:
+            if read:
+                self._read_fds.add(fd)
+                self._nursery.start_soon(self._handle_read, fd)
+
+            if write:
+                self._write_fds.add(fd)
+                self._nursery.start_soon(self._handle_write, fd)
+
+            if self._timer is None:
+                self._start_timer()
+        else:
+            # socket is now closed
+            if fd in self._read_fds:
+                self._read_fds.discard(fd)
+
+            if fd in self._write_fds:
+                self._write_fds.discard(fd)
+
+            if not self._read_fds and not self._write_fds and self._timer is not None:
+                self._timer.cancel()
+                self._timer = None
+
+    @property
+    def nameservers(self) -> Sequence[str]:
+        return self._channel.servers
+
+    @nameservers.setter
+    def nameservers(self, value: Iterable[str | bytes]) -> None:
+        self._channel.servers = value
+
+    @overload
+    def query(
+        self, host: str, qtype: Literal["A"], qclass: str | None = ...
+    ) -> Future[list[ares_query_a_result]]: ...
+    @overload
+    def query(
+        self, host: str, qtype: Literal["AAAA"], qclass: str | None = ...
+    ) -> Future[list[ares_query_aaaa_result]]: ...
+    @overload
+    def query(
+        self, host: str, qtype: Literal["CAA"], qclass: str | None = ...
+    ) -> Future[list[ares_query_caa_result]]: ...
+    @overload
+    def query(
+        self, host: str, qtype: Literal["CNAME"], qclass: str | None = ...
+    ) -> Future[ares_query_cname_result]: ...
+    @overload
+    def query(
+        self, host: str, qtype: Literal["MX"], qclass: str | None = ...
+    ) -> Future[list[ares_query_mx_result]]: ...
+    @overload
+    def query(
+        self, host: str, qtype: Literal["NAPTR"], qclass: str | None = ...
+    ) -> Future[list[ares_query_naptr_result]]: ...
+    @overload
+    def query(
+        self, host: str, qtype: Literal["NS"], qclass: str | None = ...
+    ) -> Future[list[ares_query_ns_result]]: ...
+    @overload
+    def query(
+        self, host: str, qtype: Literal["PTR"], qclass: str | None = ...
+    ) -> Future[list[ares_query_ptr_result]]: ...
+    @overload
+    def query(
+        self, host: str, qtype: Literal["SOA"], qclass: str | None = ...
+    ) -> Future[ares_query_soa_result]: ...
+    @overload
+    def query(
+        self, host: str, qtype: Literal["SRV"], qclass: str | None = ...
+    ) -> Future[list[ares_query_srv_result]]: ...
+    @overload
+    def query(
+        self, host: str, qtype: Literal["TXT"], qclass: str | None = ...
+    ) -> Future[list[ares_query_txt_result]]: ...
+
+    def query(
+        self, host: str, qtype: str, qclass: str | None = None
+    ) -> Future[list[Any]] | Future[Any]:
+        try:
+            qtype = query_type_map[qtype]
+        except KeyError as e:
+            raise ValueError(f"invalid query type: {qtype}") from e
+        if qclass is not None:
+            try:
+                qclass = query_class_map[qclass]
+            except KeyError as e:
+                raise ValueError(f"invalid query class: {qclass}") from e
+
+        # we use a different technique than pycares to try and
+        # aggressively prevent vulnerabilities
+
+        return self._wrap_future(self._channel.query(host, qtype, qclass))
+
+    def gethostbyname(
+        self, host: str, family: socket.AddressFamily
+    ) -> Future[ares_host_result]:
+        return self._wrap_future(self._channel.gethostbyname(host, family))
+
+    def getaddrinfo(
+        self,
+        host: str,
+        family: socket.AddressFamily = socket.AF_UNSPEC,
+        port: int | None = None,
+        proto: int = 0,
+        type: int = 0,
+        flags: int = 0,
+    ) -> Future[ares_addrinfo_result]:
+        return self._wrap_future(
+            self._channel.getaddrinfo(
+                host, port, family=family, type=type, proto=proto, flags=flags
+            )
+        )
+
+    def gethostbyaddr(
+        self, name: str | bytes | bytearray | memoryview
+    ) -> Future[ares_host_result]:
+        return self._wrap_future(self._channel.gethostbyaddr(name))
+
+    async def close(self) -> None:
+        """
+        Cleanly close the DNS resolver.
+
+        This should be called to ensure all resources are properly released.
+        After calling close(), the resolver should not be used again.
+        """
+        await self._cleanup()
+
+    def getnameinfo(
+        self,
+        sockaddr: tuple[str, int] | tuple[str, int, int, int],
+        flags: int = 0,
+    ) -> Future[ares_nameinfo_result]:
+        return self._wrap_future(self._channel.getnameinfo(sockaddr, flags))
+
+    def _wrap_future(self, fut: ccFuture[_T]) -> Future[_T]:
+        # use the event_thread readonly property to determine if we will be in the home thread or not.
+        return Future(fut, self._channel.event_thread)
+
+    def cancel(self) -> None:
+        """Cancels all running futures queued by this dns resolver"""
+        self._channel.cancel()
+
+    async def _cleanup(self) -> None:
+        """Cleanup timers and file descriptors when closing resolver."""
+        if self._closed:
+            return
+        # Mark as closed first to prevent double cleanup
+        self._closed = True
+        # Cancel timer if running
+        if self._timer is not None:
+            # perform safe trio cleanup
+            await self._timer.close()
+            self._timer = None
+
+        self._read_fds.clear()
+        self._write_fds.clear()
+        self._channel.cancel()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
 ]
 [project.optional-dependencies]
 idna = ["idna>=2.1"]
+trio = ["trio>=0.30.0"]
+all = ["idna>=2.1", "trio>=0.30.0"]
 
 [tool.cibuildwheel]
 build-frontend = "build"

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,5 @@
+# Testing with trio although anyio is going to replace pytest-asyncio in a later update
+anyio==4.10.0
 pytest
 # testing our version of aiodns
 pytest-asyncio
@@ -5,10 +7,11 @@ pytest-asyncio
 winloop==0.2.1; platform_system == "Windows"
 uvloop; platform_system != "Windows"
 # Utilize idna (although optional)
-idna
+idna>=2.1
 # Dummy server so that we don't end up ddosing 
 # a real dns-server
 dnslib==0.9.26
 # Benchmarking CyAres & Pycares
 pytest-codspeed==4.0.0
 pycares==4.10.0
+trio>=0.30.0

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -22,7 +22,7 @@ ChannelType = Callable[..., Channel]
 
 
 @pytest.fixture(scope="session")
-def c(request) -> Generator[Any, Any, Channel]:
+def c() -> Generator[Any, Any, Channel]:
     # should be supported on all operating systems...
     with Channel(
         servers=[
@@ -52,6 +52,8 @@ def c(request) -> Generator[Any, Any, Channel]:
             "8.8.8.8",
             "8.8.4.4",
         ],
+        tries=3,
+        timeout=10,
         event_thread=True,
     ) as channel:
         yield channel

--- a/tests/test_trio.py
+++ b/tests/test_trio.py
@@ -11,7 +11,8 @@ def anyio_backend() -> str:
 
 @pytest.fixture(
     params=(True, False),
-    ids=("trio-event-thread", "trio-socket-cb")
+    ids=("trio-event-thread", "trio-socket-cb"),
+    scope='function'
 )
 async def resolver(anyio_backend: str, request:pytest.FixtureRequest):
     # should be supported on all operating systems...

--- a/tests/test_trio.py
+++ b/tests/test_trio.py
@@ -1,0 +1,148 @@
+import pytest
+from cyares.trio import DNSResolver
+from cyares.exception import AresError
+import ipaddress
+import anyio as anyio
+
+# set the backend to just trio
+@pytest.fixture()
+def anyio_backend() -> str:
+    return 'trio'
+
+@pytest.fixture(
+    params=(True, False),
+    ids=("trio-event-thread", "trio-socket-cb")
+)
+async def resolver(anyio_backend: str, request:pytest.FixtureRequest):
+    # should be supported on all operating systems...
+
+    async with DNSResolver(
+        servers=[
+            "1.0.0.1",
+            "1.1.1.1",
+            "141.1.27.249",
+            "194.190.225.2",
+            "194.225.16.5",
+            "91.185.6.10",
+            "194.2.0.50",
+            "66.187.16.5",
+            "83.222.161.130",
+            "69.60.160.196",
+            "194.150.118.3",
+            "84.8.2.11",
+            "195.175.39.40",
+            "193.239.159.37",
+            "205.152.6.20",
+            "82.151.90.1",
+            "144.76.202.253",
+            "103.3.46.254",
+            "5.144.17.119",
+            "8.8.8.8",
+            "8.8.4.4",
+        ],
+        event_thread=request.param,
+        tries=3,
+        timeout=10
+    ) as channel:
+        yield channel
+
+
+@pytest.mark.anyio
+async def test_mx_dns_query(resolver: DNSResolver) -> None:
+    assert await resolver.query("gmail.com", "MX")
+
+
+@pytest.mark.anyio
+async def test_a_dns_query(resolver: DNSResolver) -> None:
+    assert await resolver.query("python.org", "A")
+
+
+@pytest.mark.anyio
+async def test_cancelling() -> None:
+    async with DNSResolver(servers=["8.8.8.8", "8.8.4.4"]) as channel:
+        for f in [
+            channel.query("google.com", "A"),
+            channel.query("llhttp.org", "A"),
+            channel.query("llparse.org", "A"),
+        ]:
+            f.cancel()
+
+
+@pytest.mark.anyio
+async def test_cancelling_from_resolver() -> None:
+    async with DNSResolver(servers=["8.8.8.8", "8.8.4.4"]) as resolver:
+        _ = [
+            resolver.query("google.com", "A"),
+            resolver.query("llhttp.org", "A"),
+            resolver.query("llparse.org", "A"),
+        ]
+        resolver.cancel()
+
+
+@pytest.mark.anyio
+async def test_a_dns_query_fail(resolver: DNSResolver) -> None:
+    with pytest.raises(
+        AresError,
+        match=r"\[ARES_ENODATA : 1\] DNS server returned answer with no data",
+    ):
+        await resolver.query("hgf8g2od29hdohid.com", "A")
+
+
+@pytest.mark.anyio
+async def test_query_aaaa(resolver: DNSResolver) -> None:
+    assert await resolver.query("ipv6.google.com", "AAAA")
+
+
+@pytest.mark.anyio
+async def test_query_cname(resolver: DNSResolver) -> None:
+    assert await resolver.query("www.amazon.com", "CNAME")
+
+
+@pytest.mark.anyio
+async def test_query_mx(resolver: DNSResolver) -> None:
+    assert await resolver.query("google.com", "MX")
+
+
+@pytest.mark.anyio
+async def test_query_ns(resolver: DNSResolver) -> None:
+    assert await resolver.query("google.com", "NS")
+
+
+@pytest.mark.anyio
+async def test_query_txt(resolver: DNSResolver) -> None:
+    assert await resolver.query("google.com", "TXT")
+
+
+@pytest.mark.anyio
+async def test_query_soa(resolver: DNSResolver) -> None:
+    assert await resolver.query("google.com", "SOA")
+
+
+@pytest.mark.anyio
+async def test_query_srv(resolver: DNSResolver) -> None:
+    assert await resolver.query("_xmpp-server._tcp.jabber.org", "SRV")
+
+
+@pytest.mark.anyio
+async def test_query_naptr(resolver: DNSResolver) -> None:
+    assert await resolver.query("sip2sip.info", "NAPTR")
+
+
+@pytest.mark.anyio
+async def test_query_ptr(resolver: DNSResolver) -> None:
+    assert await resolver.query(
+        ipaddress.ip_address("172.253.122.26").reverse_pointer, "PTR"
+    )
+
+
+@pytest.mark.anyio
+async def test_query_bad_type(resolver: DNSResolver) -> None:
+    with pytest.raises(ValueError):
+        await resolver.query("google.com", "XXX")
+
+
+@pytest.mark.anyio
+async def test_query_bad_class(resolver: DNSResolver) -> None:
+    with pytest.raises(ValueError):
+        await resolver.query("google.com", "A", qclass="INVALIDCLASS")
+


### PR DESCRIPTION
- This contains new tools for trio support for a `DNSResolver` which is something that is unheard of at the moment.
- Also added `anyio` to be the backbone for testing `trio` however changes will be made soon for anyio to replace `pytest-asyncio` so that we don't need as many dependencies
- `pip install cyares[trio]` install `trio` with cyares
- `pip install cyares[all]` installs cyares  with __trio__ & __idna__ together
- Code Cleanup includes mainly getting rid of training wheels or other unnecessary things...