### PR TITLE
Compile cares once instead 5 times

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ all = ["idna>=2.1", "trio>=0.30.0"]
 
 [tool.cibuildwheel]
 build-frontend = "build"
+enable = ["cpython-freethreading"]
+
 
 [build-system]
 requires = ["setuptools", "cython", "wheel"]


### PR DESCRIPTION
This Should cut off approximately 25 minutes off the current time needed to compile these wheels I don't think waiting for 30 minutes is a good idea so to prevent that I made it compile a static lib and then it links that build across all 5 sources before completion.