### PR TITLE
add aiohttp support and start using deprecated-params temporarly

### DIFF
--- a/cyares/aio.py
+++ b/cyares/aio.py
@@ -21,6 +21,8 @@ from concurrent.futures import Future as cc_Future
 from logging import getLogger
 from typing import Any, Iterable, Literal, Sequence, TypeVar, overload
 
+from deprecated_params import deprecated_params
+
 from .channel import *  # type: ignore
 from .exception import AresError
 from .resulttypes import *
@@ -61,10 +63,21 @@ query_class_map = {
 }
 
 
-# Simillar to aiodns's version but more compact
+@deprecated_params(
+    ["sock_state_cb"],
+    {
+        "socket_state_cb": "providing socket_state_cb will throw an Exception instead "
+        "of being ignored in a future version of cyares"
+    },
+    removed_in="0.1.8",
+)
 class DNSResolver:
+    """Simillar to aiodns's version but it aims to be more compact and have better typehints"""
+
     def __init__(
         self,
+        # TODO: Deprecate nameservers and rename to servers instead so that unwanted arguments
+        # can't overlap with servers argument
         nameservers: list[str] | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
         event_thread: bool = True,
@@ -177,6 +190,7 @@ class DNSResolver:
 
     async def _cleanup(self) -> None:
         """Cleanup timers and file descriptors when closing resolver."""
+        # TODO: Add Checkpoint so things remain asynchronous
         if self._closed:
             return
         # Mark as closed first to prevent double cleanup
@@ -390,9 +404,6 @@ class DNSResolver:
     #             qclass = query_class_map[qclass]
     #         except KeyError as e:
     #             raise ValueError(f"invalid query class: {qclass}") from e
-
-    #     # we use a different technique than pycares to try and
-    #     # aggressively prevent vulnerabilities
 
     #     return self._wrap_future(self._channel.query(host, qtype, qclass))
 

--- a/cyares/aiohttp.py
+++ b/cyares/aiohttp.py
@@ -1,0 +1,161 @@
+"""
+aiohttp
+-------
+
+DNS Resolver Extension for replacing `AsyncResolver` or `ThreadedResolver`
+in trade for `cyares` for handling aiohttp related http requests.
+
+## Using Globally (Monkey Patch Method)
+
+`install()` applies a monkeypatch globally
+Know that if you wanted to use different resolvers with
+aiohttp you can do that by passing `CyAresResolver` through to the
+`ClientSession`. another way
+to avoid `install()` not being threadsafe is by
+installing before the rest of your code begins running.
+Same as how **uvloop** and **winloop** both work
+
+::
+
+    from cyares.aiohttp import install
+
+    if __name__ == "__main__":
+        install()
+
+when your done with an evenloop run and want to rerun
+another but with an alternate dnsresolver such as **aiodns**
+or the `ThreadedResolver` use `uninstall()`
+
+# Using Non-Globally
+
+Although slightly more tricky it is possible to pass along `CyAresResolver`
+with the right setup without resorting to `install()`. This will also
+work with aiohttp_socks or using aiohttp_socks with a proxy or tor or i2p.
+If you feel uncomfortable with sending this much stuff to `ClientSession`
+yourself it's encouraged to use globally with `install()` or via
+monkeypatching aiohttp's default dns resolver in your own way.
+
+::
+
+    from cyares.aiohttp import CyAresResolver
+    from aiohttp import ClientSession, TCPConnector
+
+    # NOTE: This should also be respected when aiohttp_socks is in use
+    # Such as the ProxyConnector which is another connector type of it's
+    # own
+
+    async def main():
+        async with ClientSession(
+            connector=TCPConnector(CyAresResolver()
+        )) as client:
+            async with client.get("https://httpbin.org/ip") as result:
+                data = await result.json()
+                print(f'YOUR IP ADDRESS IS: {data["origin"]}')
+
+"""
+
+import asyncio
+import socket
+from typing import Optional, Union
+
+import aiohttp
+from aiohttp.abc import AbstractResolver, ResolveResult
+
+from .aio import DNSResolver
+from .exception import AresError
+
+_NUMERIC_SOCKET_FLAGS = socket.AI_NUMERICHOST | socket.AI_NUMERICSERV
+_AI_ADDRCONFIG = socket.AI_ADDRCONFIG
+if hasattr(socket, "AI_MASK"):
+    _AI_ADDRCONFIG &= socket.AI_MASK
+
+
+class CyAresResolver(AbstractResolver):
+    def __init__(
+        self, loop: Optional[asyncio.AbstractEventLoop] = None, *args, **kwargs
+    ) -> None:
+        # we already have getaddrinfo implemented in our version so
+        # no need to write more functions than the required ones
+        self._resolver = DNSResolver(loop=loop, *args, **kwargs)
+        self._loop = loop or asyncio.get_event_loop()
+
+    async def resolve(
+        self, host: str, port: int = 0, family=socket.AF_INET
+    ) -> list[ResolveResult]:
+        """Return IP address for given hostname"""
+        try:
+            resp = await self._resolver.getaddrinfo(
+                host=host,
+                port=port,
+                type=socket.SOCK_STREAM,
+                family=family,
+                flags=_AI_ADDRCONFIG,
+            )
+        except AresError as exc:
+            msg = (
+                exc.strerror.decode("utf-8", "surrogateescape")
+                if exc.status >= 1
+                else "DNS lookup failed"
+            )
+            raise OSError(None, msg) from exc
+        hosts: list[ResolveResult] = []
+        for node in resp.nodes:
+            address: Union[tuple[bytes, int], tuple[bytes, int, int, int]] = node.addr
+            family = node.family
+            if family == socket.AF_INET6:
+                # check scope ID to see if we need
+                # to recurse
+                if len(address) > 3 and address[3]:
+                    result = await self._resolver.getnameinfo(
+                        (address[0].decode("ascii"), *address[1:])
+                    )
+                    # XXX: Seems aiohttp forgot about
+                    # decoding ascii here Maybe a pull request on their end would fix that?
+                    resolved_host = result.node.decode("ascii")
+                else:
+                    resolved_host = address[0].decode("ascii")
+                    port = address[1]
+            else:
+                assert family == socket.AF_INET
+                resolved_host = address[0].decode("ascii")
+                port = address[1]
+
+            hosts.append(
+                ResolveResult(
+                    hostname=host,
+                    host=resolved_host,
+                    port=port,
+                    family=family,
+                    proto=0,
+                    flags=_NUMERIC_SOCKET_FLAGS,
+                )
+            )
+
+        # There were no results
+        if not hosts:
+            raise OSError(None, "DNS lookup failed")
+
+        return hosts
+
+    async def close(self) -> None:
+        # Our version of aiodns has a different mechanism for closure
+        # we need all these to close so that cleanup works correctly.
+        await self._resolver.close()
+
+
+PreviousDefaultResolver = aiohttp.resolver.DefaultResolver
+"""Module Variable that is responsible for undoing CyAres 
+aiohttp installation if nessesary"""
+
+
+def install():
+    """Simillar to how winloop & uvloop work, this function
+    Monkey-Patches aiohttp's `DefaultResolver` and replaces it
+    in trade for the `CyAresResolver`"""
+    aiohttp.resolver.DefaultResolver = CyAresResolver
+
+
+def uninstall():
+    """Replaces Monkey-Patched aiohttp resolver for what was there originally
+    good for situations such as testing different DNS Resolvers with `pytest`"""
+    aiohttp.resolver.DefaultResolver = PreviousDefaultResolver

--- a/cyares/channel.pyx
+++ b/cyares/channel.pyx
@@ -535,6 +535,7 @@ cdef class Channel:
         cdef object fut = self.__create_future(callback)
         cdef Py_buffer view
 
+        # TODO: use match ...: cases when cython releases match support 
         if isinstance(qtype, str):
             try:
                 _qtype = <int>self._query_lookups[qtype]

--- a/cyares/exception.pyi
+++ b/cyares/exception.pyi
@@ -7,5 +7,9 @@ This only contains one class and that is AresError
 
 class AresError(Exception):
     """Raised when c-ares fails to do something"""
+
+    status: int
+    strerror: bytes
+    name: bytes
     def __init__(self, status: int) -> None: ...
     def __str__(self) -> str: ...

--- a/cyares/resulttypes.pyi
+++ b/cyares/resulttypes.pyi
@@ -1,6 +1,4 @@
-from typing import ClassVar
-
-from _typeshed import Incomplete
+from typing import Optional, Union
 
 __test__: dict
 
@@ -15,7 +13,8 @@ class ares_addrinfo_cname_result(AresResult):
     ttl: int
 
 class ares_addrinfo_node_result(AresResult):
-    addr: bytes
+    # One of two things is (address, port) or adding in flow_info and scope_id
+    addr: Union[tuple[bytes, int], tuple[bytes, int, int, int]]
     family: int
     flags: int
     protocol: int
@@ -33,7 +32,7 @@ class ares_host_result(AresResult):
 
 class ares_nameinfo_result(AresResult):
     node: bytes
-    service: bytes | None
+    service: Optional[bytes]
 
 class ares_query_a_result(AresResult):
     host: bytes
@@ -67,7 +66,7 @@ class ares_query_ns_result(AresResult):
 
 class ares_query_ptr_result(AresResult):
     aliases: list[bytes]
-    name: Incomplete
+    name: bytes
     ttl: int
 
 class ares_query_soa_result(AresResult):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,32 @@ requires-python = ">=3.9"
 
 dependencies = [
     # Self argument
-    'typing-extensions; python_version<"3.11"'    
-    # Planned but not ready...
-    # "yarl>=1.20.1"
+    'typing-extensions; python_version<"3.11"',
+    # temporary until Cyares 0.1.7
+    # I also am the main author of deprecated-params
+    'deprecated-params>=0.1.6'
+
+    # yarl support is planned but not ready, 
+    # I would like for yarl to have a cimport for URL objects first before
+    # I start using it with this project so that maximum performance can
+    # be achieved and before that can happen 3 things must take place for 
+    # that to be completed. 
+
+    # 1. propcache which yarl utilizes needs to be cimportable,
+    #   I have already wrote a pull request that would do that it 
+    #   just needs the stamp of approval by another maintainer.
+    # 2. multidict needs a CPython capsule, this should be avalible in 6.7
+    # 3. yarl will need a cython branch not just for Quoting/UnQuoting but also 
+    # for URL objects and an __init__.pxd file for importing with cython
+  
 ]
+
 [project.optional-dependencies]
+aiohttp = ["aiohttp>=3.12.15"]
+all = ["idna>=2.1", "trio>=0.30.0", "aiohttp>=3.12.15"]
 idna = ["idna>=2.1"]
 trio = ["trio>=0.30.0"]
-all = ["idna>=2.1", "trio>=0.30.0"]
+
 
 [tool.cibuildwheel]
 build-frontend = "build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cyares"
-version = "0.1.3"
+version = "0.1.4"
 description = "A Cython Version of c-ares"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
There is a bit of changes made that mainly revolve around adding more documentation but also making sure that users know how to use the aiohttp extension of cyares. 