### PR TITLE
remove handles from Channel object and let c-ares do the rest

### DIFF
--- a/cyares/aio.py
+++ b/cyares/aio.py
@@ -64,11 +64,9 @@ query_class_map = {
 
 
 @deprecated_params(
-    ["sock_state_cb"],
-    {
-        "socket_state_cb": "providing socket_state_cb will throw an Exception instead "
-        "of being ignored in a future version of cyares"
-    },
+    "sock_state_cb",
+    "providing socket_state_cb will throw an Exception instead "
+    "of being ignored in a future version of cyares",
     removed_in="0.1.8",
 )
 class DNSResolver:

--- a/cyares/channel.pxd
+++ b/cyares/channel.pxd
@@ -19,7 +19,6 @@ cdef class Channel:
         uint64_t _running
         uint64_t _closed
 
-        set handles
         dict _query_lookups
         bint _cancelled
         

--- a/cyares/handles.pxi
+++ b/cyares/handles.pxi
@@ -1,6 +1,7 @@
 from concurrent.futures import Future as _Future
 
-# XXX: Planning to move this all to Cython in the future but for now were stuck with this...
+# There's a big surprise for 1.6 up ahead that will involve a new Chained Future Object.
 
 cdef Future = _Future
+
 

--- a/cyares/trio.py
+++ b/cyares/trio.py
@@ -168,7 +168,7 @@ class Future(Generic[_T]):
 
 
 @deprecated_params(
-    ["sock_state_cb"],
+    "sock_state_cb",
     "attempting to pass socket_state_cb will throw an Exception instead "
     "of being ignored in a future version of cyares",
     removed_in="0.1.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     'typing-extensions; python_version<"3.11"',
     # temporary until Cyares 0.1.7
     # I also am the main author of deprecated-params
-    'deprecated-params>=0.1.6'
+    'deprecated-params>=0.1.7'
 
     # yarl support is planned but not ready, 
     # I would like for yarl to have a cimport for URL objects first before

--- a/setup.py
+++ b/setup.py
@@ -123,10 +123,12 @@ class cares_build_ext(build_ext):
     ]
 
     def initialize_options(self):
-        super().initialize_options()
         self.cython_always = False
         self.cython_annotate = False
         self.cython_directives = None
+        self.parallel = True
+        super().initialize_options()
+        
         
     def add_include_dir(self, dir, force=False):
         if use_system_lib and not force:
@@ -290,6 +292,8 @@ class cares_build_ext(build_ext):
                 compiler_directives=directives,
                 annotate=self.cython_annotate,
                 emit_linenums=self.debug,
+                # Try using a cache to help with compiling as well...
+                cache=True
             )
 
         return super().finalize_options()
@@ -299,23 +303,26 @@ if __name__ == "__main__":
     setup(
         ext_modules=[
             Extension(
-                "cyares.callbacks", ["cyares/callbacks.pyx"], extra_compile_args=["-O2"]
+                "cyares.callbacks", ["cyares/callbacks.pyx"], 
+                # extra_compile_args=["-O2"]
             ),
             Extension(
-                "cyares.channel", ["cyares/channel.pyx"], extra_compile_args=["-O2"]
+                "cyares.channel", ["cyares/channel.pyx"], 
+                # extra_compile_args=["-O2"]
             ),
             Extension(
-                "cyares.exception", ["cyares/exception.pyx"], extra_compile_args=["-O2"]
+                "cyares.exception", ["cyares/exception.pyx"], 
+                # extra_compile_args=["-O2"]
             ),
             Extension(
                 "cyares.resulttypes",
                 ["cyares/resulttypes.pyx"],
-                extra_compile_args=["-O2"],
+                # extra_compile_args=["-O2"],
             ),
             Extension(
                 "cyares.socket_handle",
                 ["cyares/socket_handle.pyx"],
-                extra_compile_args=["-O2"],
+                # extra_compile_args=["-O2"],
             ),
         ],
         cmdclass={"build_ext": cares_build_ext},

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -2,7 +2,7 @@ import os
 import sys
 from concurrent.futures import Future
 
-import pycares
+
 import pytest
 from dnslib.dns import RR, DNSQuestion
 from dnslib.server import BaseResolver, DNSHandler, DNSRecord, DNSServer
@@ -12,6 +12,9 @@ import cyares
 from cyares.exception import AresError
 
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
+
+pycares = pytest.importorskip("pycares")
+
 
 if sys.version_info < (3, 11):
     from typing_extensions import Self


### PR DESCRIPTION
- I optimized and got rid of the need for needing to Track `Future` objects since c-ares is more than capable of tracking these for us. 
- There's a big surprise for 1.6 that will involve a new low level library being implemented for helping to chain parent and child futures together so that Future objects can have a small performance boost vs using `concurrent.futures.Future`. 