### PR TITLE
add faster Future objects

### DIFF
--- a/cyares/channel.pxd
+++ b/cyares/channel.pxd
@@ -2,10 +2,9 @@ from libc.stdint cimport uint64_t
 
 from .ares cimport *
 from .exception cimport AresError
+from .handles cimport Future
 from .resulttypes cimport *
 from .socket_handle cimport SocketHandle
-
-include "handles.pxi"
 
 
 cdef class Channel:
@@ -30,9 +29,9 @@ cdef class Channel:
 
     cpdef void cancel(self) noexcept
     cdef void* _malloc(self, size_t size) except NULL
-    cdef object _query(self, object qname, object qtype, int qclass, object callback)
-    cdef object _search(self, object qname, object qtype, int qclass, object callback)
-    cdef object __create_future(self, object callback)
+    cdef Future _query(self, object qname, object qtype, int qclass, object callback)
+    cdef Future _search(self, object qname, object qtype, int qclass, object callback)
+    cdef Future __create_future(self, object callback)
     cdef ares_status_t __wait(self, int milliseconds)
 
 

--- a/cyares/channel.pyi
+++ b/cyares/channel.pyi
@@ -1,7 +1,9 @@
-import sys
-from concurrent.futures import Future
-from typing import Callable, Literal, TypeVar, overload
+from __future__ import annotations
 
+import sys
+from typing import Callable, Literal, overload
+
+from .handles import Future
 from .resulttypes import *
 
 if sys.version_info < (3, 11):

--- a/cyares/handles.pxd
+++ b/cyares/handles.pxd
@@ -1,0 +1,144 @@
+
+cimport cython
+from cpython.long cimport PyLong_FromVoidPtr
+
+# DEF FIRST_COMPLETED = 'FIRST_COMPLETED'
+# DEF FIRST_EXCEPTION = 'FIRST_EXCEPTION'
+# DEF ALL_COMPLETED = 'ALL_COMPLETED'
+
+# In the future I know users will want this code elsewhere so Seperation is planned
+# in the following serveral updates depening on when condition varaibles get optimized.
+
+cdef enum fut_states:
+    PENDING
+    RUNNING
+    CANCELLED
+    CANCELLED_AND_NOTIFIED
+    FINISHED
+
+
+cdef str _STATE_TO_DESCRIPTION_MAP(fut_states state)
+
+# XXX: Python doesn't document how id() internally works but 
+# here's a pure definition of it, with the only thing I'm skipping over being sys.audit(...)
+cdef inline object c_id(object obj):
+    return PyLong_FromVoidPtr(<void*>obj)
+
+
+cdef class Error(Exception):
+    """Base class for all future-related exceptions."""
+    pass
+
+cdef class CancelledError(Error):
+    """The Future was cancelled."""
+    pass
+
+# NOTE TimeoutError is already implemented into everything so There's No need for it here...
+
+cdef class InvalidStateError(Error):
+    """The operation is not allowed in this state."""
+    pass
+
+# It didn't make sense not to include the waiters into the equation. So I'll add them
+# in and allow cpdef for most methods so that cython can reach all of these with relative ease...
+
+cdef class Waiter:
+    cdef:
+        object event
+        list finished_futures 
+
+    cdef int _add_result(self, Future future) except -1
+    cpdef object add_result(self, Future future)
+    cdef int _add_exception(self, Future future) except -1
+    cpdef object add_exception(self, Future future)
+    cdef int _add_cancelled(self, Future future) except -1
+    cpdef object add_cancelled(self, Future future)
+
+cdef class AsCompletedWaiter(Waiter):
+    cdef:
+        object lock
+
+    cdef int _add_result(self, Future future) except -1
+    cdef int _add_exception(self, Future future) except -1
+    cdef int _add_cancelled(self, Future future) except -1
+
+cdef class FirstCompletedWaiter(Waiter):
+
+    cpdef object add_result(self, Future future)
+    cpdef object add_exception(self, Future future)
+    cpdef object add_cancelled(self, Future future)
+
+cdef class AllCompletedWaiter(Waiter):
+    cdef:
+        object lock
+        Py_ssize_t num_pending_calls
+        bint stop_on_exception
+
+    cdef void _decrement_pending_calls(self)
+    cpdef object add_result(self, Future future)
+    cpdef object add_exception(self, Future future)
+    cpdef object add_cancelled(self, Future future)
+
+cdef class _AcquireFutures:
+    cdef list futures
+
+
+cdef class DoneAndNotDoneFutures:
+    cdef:
+        public set done 
+        public set not_done
+
+cdef class Future:
+    cdef:
+        # TODO: I have been trying to code a low level condition variable
+        # for weeks with no success (It should also use atomic variables for mutexes) 
+        # If anyone wants to contribute and get this done, help is apperciated. 
+
+        # Original Author was Brian Quinlan, Modifications by Vizonex
+
+        object _condition
+        fut_states _state
+        object _result
+        object _exception
+        list _waiters
+        list _done_callbacks
+
+    # Few modifications have been made for use with the code elsewhere in 
+    # other modules without needing to call for Python a whole lot.
+
+    cdef void _invoke_callbacks(self)
+    cpdef bint cancel(self)
+
+    cpdef bint cancelled(self)
+    cpdef bint running(self)
+    cpdef bint done(self)
+    cdef object __get_result(self)
+
+    cpdef void add_done_callback(self, object fn)
+    cpdef object result(self, object timeout=?)
+    cpdef object exception(self, object timeout=?)
+    # The following methods should only be used by Executors (or Channels in our case) and in tests.
+    cpdef object set_running_or_notify_cancel(self)
+    cpdef object set_result(self, object result)
+    cpdef object set_exception(self, object exception)
+
+
+# === ASYNCIO ===
+
+# TODO: Might be able to get away with a custom Future Object for Winloop
+# based on these observations...
+
+# NOT READY CAUSES UNWANTED DEADLOCKS
+# ctypedef fused future_type:
+#     object
+#     Future
+
+
+# cpdef bint isfuture(object obj)
+# cpdef object _set_result_unless_cancelled(future_type fut, object result)
+# cpdef object _convert_future_exc(BaseException exc)
+# cdef object _set_concurrent_future_state(Future concurrent, object source)
+# cpdef object _copy_future_state(future_type source, future_type dest)
+# cpdef object _get_loop(object fut)
+# cpdef object _set_state(future_type future, future_type other)
+# cpdef object wrap_future(Future future, loop=?)

--- a/cyares/handles.pxi
+++ b/cyares/handles.pxi
@@ -1,7 +1,0 @@
-from concurrent.futures import Future as _Future
-
-# There's a big surprise for 1.6 up ahead that will involve a new Chained Future Object.
-
-cdef Future = _Future
-
-

--- a/cyares/handles.pyi
+++ b/cyares/handles.pyi
@@ -1,0 +1,251 @@
+"""
+A New and Improved version of concurrent.future._base for cyares
+"""
+
+import asyncio
+from logging import Logger
+from types import GenericAlias
+from typing import Any, Callable, Generic, TypeVar, Iterable, Sequence
+
+LOGGER: Logger = ...
+
+class Error(Exception):
+    """Base class for all future-related exceptions."""
+
+    ...
+
+class CancelledError(Error):
+    """The Future was cancelled."""
+
+    ...
+
+class InvalidStateError(Error):
+    """The operation is not allowed in this state."""
+
+    ...
+
+class _Waiter:
+    """Provides the event that wait() and as_completed() block on."""
+    def __init__(self) -> None: ...
+    def add_result(self, future: Future) -> object: ...
+    def add_exception(self, future: Future) -> object: ...
+    def add_cancelled(self, future: Future) -> object: ...
+
+class _AsCompletedWaiter(_Waiter):
+    """Used by as_completed()."""
+
+    ...
+
+class _FirstCompletedWaiter(_Waiter):
+    """Used by wait(return_when=FIRST_COMPLETED)."""
+    def add_result(self, future: Future) -> object: ...
+    def add_exception(self, future: Future) -> object: ...
+    def add_cancelled(self, future: Future) -> object: ...
+
+class _AllCompletedWaiter(_Waiter):
+    """Used by wait(return_when=FIRST_EXCEPTION and ALL_COMPLETED)."""
+    def add_result(self, future: Future) -> object: ...
+    def add_exception(self, future: Future) -> object: ...
+    def add_cancelled(self, future: Future) -> object: ...
+
+class _AcquireFutures:
+    """A context manager that does an ordered acquire of Future conditions."""
+    def __init__(self, futures: object) -> None: ...
+    def __enter__(self):  # -> None:
+        ...
+    def __exit__(self, *args):  # -> None:
+        ...
+
+def _create_and_install_waiters(
+    fs: set[Future[_T]], return_when: str
+):  # -> _AsCompletedWaiter | _FirstCompletedWaiter | _AllCompletedWaiter:
+    ...
+def _result_or_cancel(fut: Future[_T], timeout: object = ...):  # -> object:
+    ...
+
+class DoneAndNotDoneFutures: ...
+
+def wait(
+    _fs: Sequence[Future[_T]] | Iterable[Future[_T]], timeout: float | None = ..., return_when: str = ...
+):  # -> DoneAndNotDoneFutures:
+    """Wait for the futures in the given sequence to complete.
+
+    Args:
+        fs: The sequence of Futures (possibly created by different Executors) to
+            wait upon.
+        timeout: The maximum number of seconds to wait. If None, then there
+            is no limit on the wait time.
+        return_when: Indicates when this function should return. The options
+            are:
+
+            FIRST_COMPLETED - Return when any future finishes or is
+                              cancelled.
+            FIRST_EXCEPTION - Return when any future finishes by raising an
+                              exception. If no future raises an exception
+                              then it is equivalent to ALL_COMPLETED.
+            ALL_COMPLETED -   Return when all futures finish or are cancelled.
+
+    Returns:
+        A named 2-tuple of sets. The first set, named 'done', contains the
+        futures that completed (is finished or cancelled) before the wait
+        completed. The second set, named 'not_done', contains uncompleted
+        futures. Duplicate futures given to *fs* are removed and will be
+        returned only once.
+    """
+    ...
+
+_T = TypeVar("_T")
+
+class Future(Generic[_T]):
+    """Represents the result of an asynchronous computation."""
+    def __init__(self) -> None: ...
+    def __repr__(self) -> str: ...
+    def cancel(self) -> bool:
+        """Cancel the future if possible.
+
+        Returns True if the future was cancelled, False otherwise. A future
+        cannot be cancelled if it is running or has already completed.
+        """
+        ...
+
+    def cancelled(self) -> bool:
+        """Return True if the future was cancelled."""
+        ...
+
+    def running(self) -> bool:
+        """Return True if the future is currently executing."""
+        ...
+
+    def done(self) -> bool:
+        """Return True if the future was cancelled or finished executing."""
+        ...
+
+    def add_done_callback(self, fn: Callable[[Future[_T]], None]) -> Any:
+        """Attaches a callable that will be called when the future finishes.
+
+        Args:
+            fn: A callable that will be called with this future as its only
+                argument when the future completes or is cancelled. The callable
+                will always be called by a thread in the same process in which
+                it was added. If the future has already completed or been
+                cancelled then the callable will be called immediately. These
+                callables are called in the order that they were added.
+        """
+        ...
+
+    def result(self, timeout: float | None = None) -> object:
+        """Return the result of the call that the future represents.
+
+        Args:
+            timeout: The number of seconds to wait for the result if the future
+                isn't done. If None, then there is no limit on the wait time.
+
+        Returns:
+            The result of the call that the future represents.
+
+        Raises:
+            CancelledError: If the future was cancelled.
+            TimeoutError: If the future didn't finish executing before the given
+                timeout.
+            Exception: If the call raised then that exception will be raised.
+        """
+        ...
+
+    def exception(self, timeout: float | None = None) -> None:
+        """Return the exception raised by the call that the future represents.
+
+        Args:
+            timeout: The number of seconds to wait for the exception if the
+                future isn't done. If None, then there is no limit on the wait
+                time.
+
+        Returns:
+            The exception raised by the call that the future represents or None
+            if the call completed without raising.
+
+        Raises:
+            CancelledError: If the future was cancelled.
+            TimeoutError: If the future didn't finish executing before the given
+                timeout.
+        """
+        ...
+
+    def set_running_or_notify_cancel(self) -> bool:
+        """Mark the future as running or process any cancel notifications.
+
+        Should only be used by Executor implementations and unit tests.
+
+        If the future has been cancelled (cancel() was called and returned
+        True) then any threads waiting on the future completing (though calls
+        to as_completed() or wait()) are notified and False is returned.
+
+        If the future was not cancelled then it is put in the running state
+        (future calls to running() will return True) and True is returned.
+
+        This method should be called by Executor implementations before
+        executing the work associated with this future. If this method returns
+        False then the work should not be executed.
+
+        Returns:
+            False if the Future was cancelled, True otherwise.
+
+        Raises:
+            RuntimeError: if this method was already called or if set_result()
+                or set_exception() was called.
+        """
+        ...
+
+    def set_result(self, result: _T) -> None:
+        """Sets the return value of work associated with the future.
+
+        Should only be used by Executor implementations and unit tests.
+        """
+        ...
+
+    def set_exception(self, exception: object) -> None:
+        """Sets the result of the future as being the given exception.
+
+        Should only be used by Executor implementations and unit tests.
+        """
+        ...
+
+    __class_getitem__ = classmethod(GenericAlias)
+
+# NOT READY: Reason: Unwanted deadlocks.
+# def isfuture(obj: object) -> bool:
+#     """Check for a Future.
+
+#     This returns True when obj is a Future instance or is advertising
+#     itself as duck-type compatible by setting _asyncio_future_blocking.
+#     See comment in Future for more details.
+#     """
+#     ...
+
+# def _set_result_unless_cancelled(fut: Any, result: object) -> object:
+#     """Helper setting the result only if the future was not cancelled."""
+#     ...
+
+# def _convert_future_exc(exc: BaseException) -> object: ...
+# def _copy_future_state(source: Any, dest: Any) -> object:
+#     """Internal helper to copy state from another Future.
+
+#     The other Future may be a concurrent.futures.Future.
+#     """
+#     ...
+
+# def _get_loop(fut: object) -> object: ...
+# def _set_state(future: Any, other: Any) -> object: ...
+# def _chain_future(source: Any, destination: Any) -> None:
+#     """Chain two futures so that when one completes, so does the other.
+
+#     The result (or exception) of source will be copied to destination.
+#     If destination is cancelled, source gets cancelled too.
+#     Compatible with both asyncio.Future and Future.
+#     """
+#     ...
+
+# def wrap_future(
+#     future: Future[_T], loop: asyncio.AbstractEventLoop | None = None
+# ) -> asyncio.Future[_T]:
+#     """Wrap Future object."""
+#     ...

--- a/cyares/handles.pyx
+++ b/cyares/handles.pyx
@@ -1,0 +1,678 @@
+import logging
+import threading
+
+from cpython.bool cimport bool
+from cpython.list cimport PyList_Append
+from cpython.long cimport PyLong_FromVoidPtr
+from cpython.object cimport PyObject
+
+from asyncio import get_event_loop
+
+cimport cython
+
+# DEF FIRST_COMPLETED = 'FIRST_COMPLETED'
+# DEF FIRST_EXCEPTION = 'FIRST_EXCEPTION'
+# DEF ALL_COMPLETED = 'ALL_COMPLETED'
+
+
+# In the future I know users will want this code elsewhere so Seperation is planned
+# in the following serveral updates depening on when condition varaibles get optimized.
+
+cdef extern from "Python.h":
+    PyObject *PyObject_CallMethodOneArg(object obj, object name, object arg) except NULL
+    PyObject *PyObject_CallMethodNoArgs(object obj, object name) except NULL
+
+    # There is no right or wrong ways to go about this but I 
+    # would like start to trying and avoid any other external imports.
+    object Py_GenericAlias(object origin, object args)
+
+
+
+
+
+# TODO: get the logger into somewhere else...
+LOGGER = logging.getLogger("cyares.handles")
+
+
+cdef str _STATE_TO_DESCRIPTION_MAP(fut_states state):
+    if state == PENDING: 
+        return "pending"
+    elif state == RUNNING: 
+        return "running"
+    elif state == CANCELLED: 
+        return "cancelled"
+    elif state == CANCELLED_AND_NOTIFIED: 
+        return "cancelled"
+    else:
+        return "finished"
+
+
+cdef class Error(Exception):
+    """Base class for all future-related exceptions."""
+    pass
+
+cdef class CancelledError(Error):
+    """The Future was cancelled."""
+    pass
+
+# NOTE TimeoutError is already implemented into everything so There's No need for it here...
+
+cdef class InvalidStateError(Error):
+    """The operation is not allowed in this state."""
+    pass
+
+# It didn't make sense not to include the waiters into the equation. So I'll add them
+# in and allow cpdef for most methods so that cython can reach all of these with relative ease...
+
+cdef class Waiter:
+    """Provides the event that wait() and as_completed() block on."""
+
+    def __cinit__(self):
+        self.event = threading.Event()
+        self.finished_futures = []
+
+    cdef int _add_result(self, Future future) except -1:
+        return PyList_Append(self.finished_futures, future)
+
+    cpdef object add_result(self, Future future):
+        if self._add_result(future) < 0:
+            raise
+
+    cdef int _add_exception(self, Future future) except -1:
+        return PyList_Append(self.finished_futures, future)
+
+    cpdef object add_exception(self, Future future):
+        if self._add_exception(future) < 0:
+            raise
+
+    cdef int _add_cancelled(self, Future future) except -1:
+        return PyList_Append(self.finished_futures, future)
+    
+    cpdef object add_cancelled(self, Future future):
+        if self._add_cancelled(future) < 0:
+            raise
+
+cdef class AsCompletedWaiter(Waiter):
+    """Used by as_completed()."""
+    def __init__(self) -> None:
+        super().__init__()
+        self.lock = threading.Lock()
+
+    cdef int _add_result(self, Future future) except -1:
+        with self.lock:
+            if super()._add_result(future) < 0:
+                return -1
+            self.event.set()
+        return 0
+
+    cdef int _add_exception(self, Future future) except -1:
+        with self.lock:
+            if self._add_exception(future) < 0:
+                return -1
+            self.event.set()
+        return 0
+
+    cdef int _add_cancelled(self, Future future) except -1:
+        with self.lock:
+            if self._add_cancelled(future) < 0: 
+                return -1
+            self.event.set()
+
+cdef class FirstCompletedWaiter(Waiter):
+    """Used by wait(return_when=FIRST_COMPLETED)."""
+
+    cpdef object add_result(self, Future future):
+        if self._add_result(future) < 0: raise
+        self.event.set()
+
+    cpdef object add_exception(self, Future future):
+        if self._add_exception(future) < 0: raise
+        self.event.set()
+
+    cpdef object add_cancelled(self, Future future):
+        if self._add_cancelled(future) < 0: raise
+        self.event.set()
+
+cdef class AllCompletedWaiter(Waiter):
+    """Used by wait(return_when=FIRST_EXCEPTION and ALL_COMPLETED)."""
+
+    def __cinit__(self, Py_ssize_t num_pending_calls, bint stop_on_exception):
+        self.num_pending_calls = num_pending_calls
+        self.stop_on_exception = stop_on_exception
+        self.event = threading.Event()
+        self.finished_futures = []
+        self.lock = threading.Lock()
+
+    cdef void _decrement_pending_calls(self):
+        with self.lock:
+            self.num_pending_calls -= 1
+            if not self.num_pending_calls:
+                self.event.set()
+
+    cpdef object add_result(self, Future future):
+        if self._add_result(future) < 0:
+            raise
+        self._decrement_pending_calls()
+
+    cpdef object add_exception(self, Future future):
+        if self._add_exception(future) < 0:
+            raise
+        if self.stop_on_exception:
+            self.event.set()
+        else:
+            self._decrement_pending_calls()
+
+    cpdef object add_cancelled(self, Future future):
+        if self._add_cancelled(future) < 0:
+            raise
+        self._decrement_pending_calls()
+
+cdef class AcquireFutures:
+    """A context manager that does an ordered acquire of Future conditions."""
+
+    def __init__(self, object futures):
+        self.futures = sorted(futures, key=id)
+
+    def __enter__(self):
+        cdef Future future
+        for future in self.futures:
+            PyObject_CallMethodNoArgs(future._condition, "acquire")
+
+    def __exit__(self, *args):
+        cdef Future future 
+        for future in self.futures:
+            PyObject_CallMethodNoArgs(future._condition, "release")
+    
+
+def _create_and_install_waiters(set fs, str return_when):
+    cdef Future f
+    if return_when == "_AS_COMPLETED":
+        waiter = AsCompletedWaiter()
+    elif return_when == "FIRST_COMPLETED":
+        waiter = FirstCompletedWaiter()
+    else:
+        pending_count = sum(
+                (f._state != CANCELLED_AND_NOTIFIED or f._state != FINISHED) for f in fs)
+
+        if return_when == "FIRST_EXCEPTION":
+            waiter = AllCompletedWaiter(pending_count, stop_on_exception=True)
+        elif return_when == "ALL_COMPLETED":
+            waiter = AllCompletedWaiter(pending_count, stop_on_exception=False)
+        else:
+            raise ValueError("Invalid return condition: %r" % return_when)
+
+    for f in fs:
+        f._waiters.append(waiter)
+
+    return waiter
+
+def _result_or_cancel(Future fut, object timeout=None):
+    try:
+        try:
+            return fut.result(timeout)
+        finally:
+            fut.cancel()
+    finally:
+        # Break a reference cycle with the exception in self._exception
+        del fut
+
+cdef class DoneAndNotDoneFutures:
+    def __cinit__(self, set done, set not_done) -> None:
+        self.done = done
+        self.not_done = not_done
+
+def wait(object _fs, object timeout=None, str return_when='ALL_COMPLETED'):
+    """Wait for the futures in the given sequence to complete.
+
+    Args:
+        fs: The sequence of Futures (possibly created by different Executors) to
+            wait upon.
+        timeout: The maximum number of seconds to wait. If None, then there
+            is no limit on the wait time.
+        return_when: Indicates when this function should return. The options
+            are:
+
+            FIRST_COMPLETED - Return when any future finishes or is
+                              cancelled.
+            FIRST_EXCEPTION - Return when any future finishes by raising an
+                              exception. If no future raises an exception
+                              then it is equivalent to ALL_COMPLETED.
+            ALL_COMPLETED -   Return when all futures finish or are cancelled.
+
+    Returns:
+        A named 2-tuple of sets. The first set, named 'done', contains the
+        futures that completed (is finished or cancelled) before the wait
+        completed. The second set, named 'not_done', contains uncompleted
+        futures. Duplicate futures given to *fs* are removed and will be 
+        returned only once.
+    """
+    cdef Future f
+    cdef set fs = set(_fs)
+    cdef Waiter waiter
+    with AcquireFutures(fs):
+        done = {f for f in fs
+                   if f._state == CANCELLED_AND_NOTIFIED or f._state == FINISHED}
+        not_done = fs - done
+        if (return_when == "FIRST_COMPLETED") and done:
+            return DoneAndNotDoneFutures(done, not_done)
+        elif (return_when == "FIRST_EXCEPTION") and done:
+            if any(f for f in done
+                   if not f.cancelled() and f.exception() is not None):
+                return DoneAndNotDoneFutures(done, not_done)
+
+        if len(done) == len(fs):
+            return DoneAndNotDoneFutures(done, not_done)
+
+        waiter = _create_and_install_waiters(fs, return_when)
+
+    PyObject_CallMethodOneArg(waiter.event, 'wait', timeout)
+    for f in fs:
+        with f._condition:
+            f._waiters.remove(waiter)
+
+    done.update(waiter.finished_futures)
+    return DoneAndNotDoneFutures(done, fs.difference(done))
+
+
+
+
+cdef class Future:
+    """Represents the result of an asynchronous computation."""
+
+    # TODO: I have been trying to code a low level condition variable
+    # for weeks with no success (It should also use atomic variables for mutexes) 
+    # If anyone wants to contribute and get this done, help is apperciated. 
+    # Original Author was Brian Quinlan, Modifications by Vizonex
+
+       
+
+    # Few modifications have been made for use with the code elsewhere in 
+    # other modules without needing to call for Python a whole lot.
+
+    def __cinit__(self):
+        """Initializes the future. Should not be called by clients."""
+        self._condition = threading.Condition()
+        self._state = PENDING
+        self._result = None
+        self._exception = None
+        self._waiters = []
+        self._done_callbacks = []
+
+    cdef void _invoke_callbacks(self):
+        for callback in self._done_callbacks:
+            try:
+                callback(self)
+            except Exception:
+                LOGGER.exception('exception calling callback for %r', self)
+
+    def __repr__(self):
+        with self._condition:
+            if self._state == FINISHED:
+                if self._exception:
+                    return '<%s at %#x state=%s raised %s>' % (
+                        self.__class__.__name__,
+                        c_id(self),
+                        _STATE_TO_DESCRIPTION_MAP(self._state),
+                        self._exception.__class__.__name__)
+                else:
+                    return '<%s at %#x state=%s returned %s>' % (
+                        self.__class__.__name__,
+                        c_id(self),
+                        _STATE_TO_DESCRIPTION_MAP(self._state),
+                        self._result.__class__.__name__)
+            return '<%s at %#x state=%s>' % (
+                    self.__class__.__name__,
+                    c_id(self),
+                   _STATE_TO_DESCRIPTION_MAP(self._state))
+
+    cpdef bint cancel(self):
+        """Cancel the future if possible.
+
+        Returns True if the future was cancelled, False otherwise. A future
+        cannot be cancelled if it is running or has already completed.
+        """
+        PyObject_CallMethodNoArgs(self._condition, "__enter__")
+
+        if self._state == RUNNING or self._state == FINISHED:
+            return False
+        
+        if self._state == CANCELLED or self._state == CANCELLED_AND_NOTIFIED:
+            return True
+
+        self._state = CANCELLED
+        PyObject_CallMethodNoArgs(self._condition, "notify_all")
+        PyObject_CallMethodOneArg(self._condition, "__exit__", (None, None, None))
+        self._invoke_callbacks()
+        return True
+
+    cpdef bint cancelled(self):
+        """Return True if the future was cancelled."""
+        with self._condition:
+            return self._state == CANCELLED or self._state == CANCELLED_AND_NOTIFIED
+
+    cpdef bint running(self):
+        """Return True if the future is currently executing."""
+        with self._condition:
+            return self._state == RUNNING
+
+    cpdef bint done(self):
+        """Return True if the future was cancelled or finished executing."""
+        with self._condition:
+            return self._state == CANCELLED or self._state == CANCELLED_AND_NOTIFIED or self._state == FINISHED
+
+    cdef object __get_result(self):
+        if self._exception:
+            try:
+                raise self._exception
+            finally:
+                # Break a reference cycle with the exception in self._exception
+                self = None
+        else:
+            return self._result
+
+    cpdef void add_done_callback(self, fn):
+        """Attaches a callable that will be called when the future finishes.
+
+        Args:
+            fn: A callable that will be called with this future as its only
+                argument when the future completes or is cancelled. The callable
+                will always be called by a thread in the same process in which
+                it was added. If the future has already completed or been
+                cancelled then the callable will be called immediately. These
+                callables are called in the order that they were added.
+        """
+        with self._condition:
+            if self._state != CANCELLED or self._state != CANCELLED_AND_NOTIFIED or self._state != FINISHED:
+                self._done_callbacks.append(fn)
+                return
+        try:
+            fn(self)
+        except Exception:
+            LOGGER.exception('exception calling callback for %r', self)
+
+    cpdef object result(self, object timeout=None):
+        """Return the result of the call that the future represents.
+
+        Args:
+            timeout: The number of seconds to wait for the result if the future
+                isn't done. If None, then there is no limit on the wait time.
+
+        Returns:
+            The result of the call that the future represents.
+
+        Raises:
+            CancelledError: If the future was cancelled.
+            TimeoutError: If the future didn't finish executing before the given
+                timeout.
+            Exception: If the call raised then that exception will be raised.
+        """
+        try:
+            with self._condition:
+                if self._state == CANCELLED or self._state == CANCELLED_AND_NOTIFIED:
+                    raise CancelledError()
+                elif self._state == FINISHED:
+                    return self.__get_result()
+
+                # I Have to do this otherwise we get into a deadlock.
+                PyObject_CallMethodOneArg(self._condition, "wait", timeout)
+
+                if self._state == CANCELLED or self._state == CANCELLED_AND_NOTIFIED:
+                    raise CancelledError()
+                elif self._state == FINISHED:
+                    return self.__get_result()
+                else:
+                    raise TimeoutError()
+        finally:
+            # Break a reference cycle with the exception in self._exception
+            self = None
+
+    cpdef object exception(self, object timeout=None):
+        """Return the exception raised by the call that the future represents.
+
+        Args:
+            timeout: The number of seconds to wait for the exception if the
+                future isn't done. If None, then there is no limit on the wait
+                time.
+
+        Returns:
+            The exception raised by the call that the future represents or None
+            if the call completed without raising.
+
+        Raises:
+            CancelledError: If the future was cancelled.
+            TimeoutError: If the future didn't finish executing before the given
+                timeout.
+        """
+
+        with self._condition:
+            if self._state == CANCELLED or self._state == CANCELLED_AND_NOTIFIED:
+                raise CancelledError()
+            elif self._state == FINISHED:
+                return self._exception
+
+            # I Have to do this otherwise we get a deadlock.
+            PyObject_CallMethodOneArg(self._condition, "wait", timeout)
+
+            if self._state == CANCELLED or self._state == CANCELLED_AND_NOTIFIED:
+                raise CancelledError()
+            elif self._state == FINISHED:
+                return self._exception
+            else:
+                raise TimeoutError()
+
+    # The following methods should only be used by Executors (or Channels in our case) and in tests.
+    cpdef object set_running_or_notify_cancel(self):
+        """Mark the future as running or process any cancel notifications.
+
+        Should only be used by Executor implementations and unit tests.
+
+        If the future has been cancelled (cancel() was called and returned
+        True) then any threads waiting on the future completing (though calls
+        to as_completed() or wait()) are notified and False is returned.
+
+        If the future was not cancelled then it is put in the running state
+        (future calls to running() will return True) and True is returned.
+
+        This method should be called by Executor implementations before
+        executing the work associated with this future. If this method returns
+        False then the work should not be executed.
+
+        Returns:
+            False if the Future was cancelled, True otherwise.
+
+        Raises:
+            RuntimeError: if this method was already called or if set_result()
+                or set_exception() was called.
+        """
+        cdef Waiter waiter
+
+        with self._condition:
+            if self._state == CANCELLED:
+                self._state = CANCELLED_AND_NOTIFIED
+                for waiter in self._waiters:
+                    waiter.add_cancelled(self)
+                # self._condition.notify_all() is not necessary because
+                # self.cancel() triggers a notification.
+                return False
+            elif self._state == PENDING:
+                self._state = RUNNING
+                return True
+            else:
+                LOGGER.critical('Future %s in unexpected state: %s',
+                                id(self),
+                                self._state)
+                raise RuntimeError('Future in unexpected state')
+
+    cpdef object set_result(self, object result):
+        """Sets the return value of work associated with the future.
+
+        Should only be used by Executor implementations and unit tests.
+        """
+        with self._condition:
+            if self._state == CANCELLED or self._state == CANCELLED_AND_NOTIFIED or self._state == FINISHED:
+                raise InvalidStateError('{}: {!r}'.format(self._state, self))
+            self._result = result
+            self._state = FINISHED
+            for waiter in self._waiters:
+                waiter.add_result(self)
+            PyObject_CallMethodNoArgs(self._condition, "notify_all")
+        self._invoke_callbacks()
+
+    cpdef object set_exception(self, object exception):
+        """Sets the result of the future as being the given exception.
+
+        Should only be used by Executor implementations and unit tests.
+        """
+        with self._condition:
+            if self._state == CANCELLED or self._state == CANCELLED_AND_NOTIFIED or self._state == FINISHED:
+                raise InvalidStateError('{}: {!r}'.format(self._state, self))
+            self._exception = exception
+            self._state = FINISHED
+            for waiter in self._waiters:
+                waiter.add_exception(self)
+            PyObject_CallMethodNoArgs(self._condition, "notify_all")
+        self._invoke_callbacks()
+
+    # I feel a lot safer about Py_GenericAlias than types.GenericAlias
+    # TODO: (Vizonex) I am a contributor of the frozenlist library so 
+    # Maybe it should be implemented there as well?
+    @classmethod
+    def __class_getitem__(cls, *args):
+        return Py_GenericAlias(cls, args)
+
+
+
+# === ASYNCIO ===
+
+# TODO: Might be able to get away with a custom Future Object for Winloop
+# based on these observations...
+
+
+# NOT READY!!!
+
+# cpdef bint isfuture(object obj):
+#     """Check for a Future.
+
+#     This returns True when obj is a Future instance or is advertising
+#     itself as duck-type compatible by setting _asyncio_future_blocking.
+#     See comment in Future for more details.
+#     """
+#     return (hasattr(obj.__class__, '_asyncio_future_blocking') and
+#             getattr(obj, "_asyncio_future_blocking", None) is not None)
+
+
+# cpdef object _set_result_unless_cancelled(future_type fut, object result):
+#     """Helper setting the result only if the future was not cancelled."""
+#     if fut.cancelled():
+#         return
+#     fut.set_result(result)
+
+
+# cpdef object _convert_future_exc(BaseException exc):
+#     exc_class = type(exc)
+#     if exc_class is CancelledError:
+#         return CancelledError(*exc.args)
+#     elif exc_class is TimeoutError:
+#         return TimeoutError(*exc.args)
+#     elif exc_class is InvalidStateError:
+#         return InvalidStateError(*exc.args)
+#     else:
+#         return exc
+
+
+# cdef object _set_concurrent_future_state(Future concurrent, object source):
+#     """Copy state from a future to a concurrent.futures.Future."""
+#     assert source.done()
+#     if source.cancelled():
+#         concurrent.cancel()
+#     if not concurrent.set_running_or_notify_cancel():
+#         return
+#     exception = source.exception()
+#     if exception is not None:
+#         concurrent.set_exception(_convert_future_exc(exception))
+#     else:
+#         result = source.result()
+#         concurrent.set_result(result)
+
+# cpdef object _copy_future_state(future_type source, future_type dest):
+#     """Internal helper to copy state from another Future.
+
+#     The other Future may be a concurrent.futures.Future.
+#     """
+#     assert source.done()
+#     if dest.cancelled():
+#         return
+#     assert not dest.done()
+#     if source.cancelled():
+#         dest.cancel()
+#     else:
+#         exception = source.exception()
+#         if exception is not None:
+#             dest.set_exception(_convert_future_exc(exception))
+#         else:
+#             result = source.result()
+#             dest.set_result(result)
+
+# cpdef object _get_loop(object fut):
+#     # Tries to call Future.get_loop() if it's available.
+#     # Otherwise fallbacks to using the old '_loop' property.
+#     try:
+#         return <object>PyObject_CallMethodNoArgs(fut, "get_loop")
+#     except AttributeError:
+#         return getattr(fut, "_loop")
+    
+
+# cpdef object _set_state(future_type future, future_type other):
+#     if isfuture(future):
+#         _copy_future_state(other, future)
+#     else:
+#         _set_concurrent_future_state(future, other)
+
+
+# def _chain_future(Future source, object destination):
+#     """Chain two futures so that when one completes, so does the other.
+
+#     The result (or exception) of source will be copied to destination.
+#     If destination is cancelled, source gets cancelled too.
+#     Compatible with both asyncio.Future and Future.
+#     """
+#     if not isfuture(source) and not isinstance(source, Future):
+#         raise TypeError('A future is required for source argument')
+#     if not isfuture(destination) and not isinstance(destination, Future):
+#         raise TypeError('A future is required for destination argument')
+#     # source_loop = _get_loop(source) if isfuture(source) else None
+#     dest_loop = _get_loop(destination) if isfuture(destination) else None
+
+#     def _call_check_cancel(object destination):
+#         if destination.cancelled():
+#             source.cancel()
+#         # if destination.cancelled():
+#         #     if source_loop is None or source_loop is dest_loop:
+#         #         source.cancel()
+#         #     else:
+#         #         source_loop.call_soon_threadsafe(source.cancel)
+
+#     def _call_set_state(object source):
+#         if (destination.cancelled() and
+#                 dest_loop is not None and dest_loop.is_closed()):
+#             return
+#         if dest_loop is None:
+#             _set_state(destination, source)
+#         else:
+#             if dest_loop.is_closed():
+#                 return
+#             dest_loop.call_soon_threadsafe(_set_state, destination, source)
+
+#     destination.add_done_callback(_call_check_cancel)
+#     source.add_done_callback(_call_set_state)
+
+# cpdef object wrap_future(Future future, loop=None):
+#     """Wrap concurrent.futures.Future object."""
+#     cdef object new_future
+#     # if isfuture(future):
+#     #     return future
+#     # assert isinstance(future, Future), \
+#     #     f'Future is expected, got {future!r}'
+#     new_future = (loop or get_event_loop()).create_future()
+#     _chain_future(future, new_future)
+#     return new_future

--- a/cyares/trio.py
+++ b/cyares/trio.py
@@ -192,8 +192,7 @@ class DNSResolver:
         local_ip: str | bytes | bytearray | memoryview[int] | None = None,
         local_dev: str | bytes | bytearray | memoryview[int] | None = None,
         resolvconf_path=None,
-        
-        **kw
+        **kw,
     ):
         kw.pop("socket_state_cb", None)
 
@@ -220,7 +219,7 @@ class DNSResolver:
         self._nursery: Optional[trio.Nursery] = None
         self._read_fds: set[int] = set()
         self._write_fds: set[int] = set()
-        self._timeout = kw.get("timeout", None)
+        self._timeout = timeout
         self._timer = None
         self._token = current_trio_token()
 

--- a/setup.py
+++ b/setup.py
@@ -236,6 +236,10 @@ class cares_build_ext(build_ext):
             objects = c.compile(sources, "build")
             c.create_static_lib(objects, output_libname="cares", output_dir="build")
             for e in self.extensions:
+                if e.name == "cyares.handles":
+                    # cyares.handles doesn't need c-ares it's only the others so exclude it.
+                    continue
+
                 if "build/cares" not in e.libraries:
                     e.libraries.append("build/cares") 
         super().build_extensions()
@@ -324,6 +328,10 @@ if __name__ == "__main__":
                 ["cyares/socket_handle.pyx"],
                 # extra_compile_args=["-O2"],
             ),
+            Extension(
+                "cyares.handles",
+                ["cyares/handles.pyx"]
+            )
         ],
         cmdclass={"build_ext": cares_build_ext},
     )

--- a/tests/test_future.py
+++ b/tests/test_future.py
@@ -1,0 +1,60 @@
+from cyares.handles import Future
+from cyares.aio import wrap_future
+from threading import Thread
+import time
+import sys
+import pytest
+import asyncio
+
+uvloop = pytest.importorskip("winloop" if sys.platform == "win32" else "uvloop")
+
+PARAMS = [
+        pytest.param(
+            ("asyncio", {"loop_factory": uvloop.new_event_loop}), id="asyncio[uvloop]"
+        ),
+    pytest.param(("asyncio", {"use_uvloop": False}), id="asyncio"),
+]
+
+if sys.platform == "win32":
+    PARAMS.append(
+        pytest.param(("asyncio", {"loop_factory": asyncio.SelectorEventLoop}), id="asyncio[win32+selector]")
+    )
+@pytest.fixture(
+    params=PARAMS
+)
+def anyio_backend(request: pytest.FixtureRequest):
+    return request.param
+
+def test_set_and_get() -> None:
+    fut: Future[int] = Future()
+    fut.set_result(0)
+    assert fut.result() == 0
+
+def test_between_threads():
+    def do_result(fut:Future[int]):
+        time.sleep(0.001)
+        fut.set_result(0)
+
+    fut = Future()
+    t = Thread(target=do_result, args=(fut,))
+    t.start()
+    result = fut.result(0.2)
+    assert result == 0
+
+
+@pytest.mark.anyio
+async def test_wrapping_to_future():
+    fut = Future()
+
+    def do_result(fut:Future[int]):
+        time.sleep(0.001)
+        fut.set_result(0)
+
+    fut = Future()
+    t = Thread(target=do_result, args=(fut,))
+    t.start()
+    result = await wrap_future(fut)
+    assert result == 0
+    
+
+    


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add faster Future Object and has full Cython support which means many costly calls can be gotten rid of. I encourage the CPython Maintainers to look into Fully Merging threading.Condition to C and adding a C-API Capsule for greater speed and for preventing deadlocks with Cython.

## Are there changes in behavior for the user?

`concurrent.futures.Future` was replaced so warning to anyone relying on this object that it has been internally changed.

## Is it a substantial burden for the maintainers to support this?

Not at all in fact This was something I've been trying to add in for several weeks now.

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
