### PR TITLE
use PyMem_Raw* Allocs instead of ares's defaults

### DIFF
--- a/cyares/ares.pxd
+++ b/cyares/ares.pxd
@@ -10,6 +10,12 @@ cdef extern from  "ares_private.h" nogil:
         pass 
 
 cdef extern from "inc/cares_headers.h" nogil:
+    """
+/* wrapper helpers for cython */
+typedef void* (*cyares_amalloc)(size_t size);
+typedef void (*cyares_afree)(void *ptr);
+typedef void* (*cyares_arealloc)(void *ptr, size_t size);
+    """
     
     # ctypedef long suseconds_t
     ctypedef int h_addrtype_t
@@ -963,4 +969,14 @@ cdef extern from "inc/cares_headers.h" nogil:
     size_t ares_queue_active_queries(const ares_channel_t *channel)
 
     ares_status_t ares_queue_wait_empty(ares_channel_t *channel, int timeout_ms)
-    
+
+    # Introduced in cyares 0.1.8 typedefs are to bypass cyright's annoyances...
+    ctypedef void* (*cyares_amalloc)(size_t size) nogil
+    ctypedef void (*cyares_afree)(void *ptr) nogil
+    ctypedef void* (*cyares_arealloc)(void *ptr, size_t size) nogil
+    int ares_library_init_mem(
+        int flags, 
+        cyares_amalloc amalloc,
+        cyares_afree afree,
+        cyares_arealloc arealloc
+    )

--- a/cyares/channel.pyx
+++ b/cyares/channel.pyx
@@ -1,7 +1,7 @@
 # cython: embed_signature=Trie
 cimport cython
 from cpython.exc cimport PyErr_NoMemory, PyErr_SetObject
-from cpython.mem cimport PyMem_Free, PyMem_Malloc
+from cpython.mem cimport PyMem_Free, PyMem_Malloc, PyMem_RawMalloc, PyMem_RawRealloc, PyMem_RawFree
 from cpython.ref cimport Py_DECREF, Py_INCREF
 from cpython.unicode cimport PyUnicode_Check, PyUnicode_GetLength
 from libc.math cimport floor, fmod
@@ -1017,7 +1017,12 @@ def cyares_threadsafety():
 
 
 
-cdef int init_status = ares_library_init(ARES_LIB_INIT_ALL)
+cdef int init_status = ares_library_init_mem(
+    ARES_LIB_INIT_ALL,
+    PyMem_RawMalloc,
+    PyMem_RawFree,
+    PyMem_RawRealloc
+)
 if ARES_SUCCESS != init_status:
     raise AresError(init_status)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

We should be using PyMem_Raw* on everything to be both threadsafe but also be using python's resources instead of external resources which should help increase the performance of our tools. (This is incase of an event thread being in use)

Currently I don't have time to edit anymore things out but I should be able to review and merge the PR when I get back from work today.

## Are there changes in behavior for the user?

There should be increased performance now thanks to these edits.

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
