### PR TITLE
throw an error if `socket_state_cb` is attempted with aio and trio and remove deprecated-params

### DIFF
--- a/cyares/aio.py
+++ b/cyares/aio.py
@@ -22,8 +22,6 @@ from asyncio import wrap_future as w
 from logging import getLogger
 from typing import Any, Iterable, Literal, Sequence, TypeVar, overload
 
-from deprecated_params import deprecated_params
-
 from .channel import *  # type: ignore
 from .exception import AresError  # type: ignore
 from .handles import CancelledError
@@ -197,12 +195,6 @@ def wrap_future(
     return new_future
 
 
-@deprecated_params(
-    "sock_state_cb",
-    "providing socket_state_cb will throw an Exception instead "
-    "of being ignored in a future version of cyares",
-    removed_in="0.1.8",
-)
 class DNSResolver:
     """Simillar to aiodns's version but it aims to be more compact and have better typehints"""
 
@@ -225,7 +217,6 @@ class DNSResolver:
         local_ip: str | bytes | bytearray | memoryview[int] | None = None,
         local_dev: str | bytes | bytearray | memoryview[int] | None = None,
         resolvconf_path=None,
-        **kwargs,
     ) -> None:
         """
         Params
@@ -251,8 +242,8 @@ class DNSResolver:
         self._closed = True
         self.loop = loop or asyncio.get_event_loop()
 
-        # XXX: Do not use, we override this argument by default
-        kwargs.pop("sock_state_cb", None)
+   
+
         self._timeout = timeout
         # Internal (Using with pytest to help debug socket_cb handles)
         if event_thread:
@@ -271,8 +262,7 @@ class DNSResolver:
                 rotate=rotate,
                 local_ip=local_ip,
                 local_dev=local_dev,
-                resolvconf_path=resolvconf_path,
-                **kwargs,
+                resolvconf_path=resolvconf_path
             )
 
         else:
@@ -294,7 +284,6 @@ class DNSResolver:
                     local_ip=local_ip,
                     local_dev=local_dev,
                     resolvconf_path=None,
-                    **kwargs,
                 ),
             )
 

--- a/cyares/trio.py
+++ b/cyares/trio.py
@@ -25,7 +25,6 @@ from typing import (
 )
 
 import trio
-from deprecated_params import deprecated_params
 from trio.lowlevel import current_clock, current_trio_token
 
 from .channel import *
@@ -167,12 +166,7 @@ class Future(Generic[_T]):
         return self._wait().__await__()
 
 
-@deprecated_params(
-    "sock_state_cb",
-    "attempting to pass socket_state_cb will throw an Exception instead "
-    "of being ignored in a future version of cyares",
-    removed_in="0.1.8",
-)
+
 class DNSResolver:
     def __init__(
         self,
@@ -191,11 +185,8 @@ class DNSResolver:
         rotate: bool = False,
         local_ip: str | bytes | bytearray | memoryview[int] | None = None,
         local_dev: str | bytes | bytearray | memoryview[int] | None = None,
-        resolvconf_path=None,
-        **kw,
+        resolvconf_path=None
     ):
-        kw.pop("socket_state_cb", None)
-
         self._channel = Channel(
             servers=servers,
             event_thread=event_thread,
@@ -212,8 +203,7 @@ class DNSResolver:
             rotate=rotate,
             local_ip=local_ip,
             local_dev=local_dev,
-            resolvconf_path=resolvconf_path,
-            **kw,
+            resolvconf_path=resolvconf_path
         )
         self._manager = trio.open_nursery()
         self._nursery: Optional[trio.Nursery] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,7 @@ requires-python = ">=3.9"
 dependencies = [
     # Self argument
     'typing-extensions; python_version<"3.11"',
-    # temporary until Cyares 0.1.7
-    # I also am the main author of deprecated-params
-    'deprecated-params>=0.1.7'
-
+    
     # yarl support is planned but not ready, 
     # I would like for yarl to have a cimport for URL objects first before
     # I start using it with this project so that maximum performance can


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

Expiration of my original deprecation warning is now in session and with that comes changes. 
Deprecated-Params has served it's purpose well and I hope to bring it back in the future if things become an issue again 
there are things to improve like removing callbacks in the dns-resolver after 0.2.0 since I will be changing how we do versioning around here. Where each digit goes as follows 

- number or rewrites
- number for newly implemented features 
- number of patches & Bug fixes

I'll come back after work today to handle merging tests turn out successful.

## Are there changes in behavior for the user?

deprecated-params is not a required dependency here anymore and can be safely dropped until we decide to use it again. 
Deprecated-Params is getting a brand new cython branch in the future for not just speedups but also for utilization in Cython (should be understandable as to why I am doing so) such as upping deprecated-params's performance and benchmarks but also adding into Cython as a bonus. 

## Is it a substantial burden for the maintainers to support this?

Nope, it eases things a little for me as the owner. Less stressful moving parts to worry about so hopefully that comes with more speed on top of everything else :)

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
