### PR TITLE
move MX, AAAA, A to dns_rec instead

### DIFF
--- a/cyares/callbacks.pxd
+++ b/cyares/callbacks.pxd
@@ -1,21 +1,20 @@
 from .ares cimport *
 
 
-cdef void __callback_query_on_a(
-    void *arg,
-    int status,
-    int timeouts,
-    unsigned char *abuf,
-    int alen
+cdef void __callback_dns_rec__a(
+    void *arg, 
+    ares_status_t status,
+    size_t timeouts,
+    const ares_dns_record_t *dnsrec
 ) noexcept with gil
 
 
-cdef void __callback_query_on_aaaa(
-    void *arg,
-    int status,
-    int timeouts,
-    unsigned char *abuf,
-    int alen
+
+cdef void __callback_dns_rec__aaaa(
+    void *arg, 
+    ares_status_t status,
+    size_t timeouts,
+    const ares_dns_record_t *dnsrec
 ) noexcept with gil
 
 
@@ -28,7 +27,6 @@ cdef void __callback_query_on_caa(
 ) noexcept with gil
 
 
-
 cdef void __callback_query_on_cname(
     void *arg,
     int status,
@@ -38,15 +36,12 @@ cdef void __callback_query_on_cname(
 ) noexcept with gil
 
 
-
-cdef void __callback_query_on_mx(
-    void *arg,
-    int status,
-    int timeouts,
-    unsigned char *abuf,
-    int alen
+cdef void __callback_dns_rec__mx(
+    void *arg, 
+    ares_status_t status,
+    size_t timeouts,
+    const ares_dns_record_t *dnsrec
 ) noexcept with gil
-
 
 cdef void __callback_query_on_naptr(
     void *arg,

--- a/cyares/channel.pyx
+++ b/cyares/channel.pyx
@@ -414,10 +414,12 @@ cdef class Channel:
     # _query is a lower-level C Function
     # query is the upper-end and is meant to assist in
     # being a theoretical drop in replacement for pycares in aiodns
+ 
     cdef Future _query(self, object qname, object qtype, int qclass, object callback):
         cdef int _qtype
         cdef Future fut 
         cdef Py_buffer view
+        cdef ares_status_t status
 
         if isinstance(qtype, str):
             try:
@@ -435,24 +437,31 @@ cdef class Channel:
 
         fut = self.__create_future(callback)
         if _qtype == T_A:
-            ares_query(
+            status = ares_query_dnsrec(
                 self.channel,
                 <char*>view.buf,
-                qclass,
-                T_A,
-                __callback_query_on_a, # type: ignore
-                <void*>fut
+                <ares_dns_class_t>qclass,
+                ARES_REC_TYPE_A,
+                __callback_dns_rec__a, # type: ignore
+                <void*>fut,
+                NULL, # Passing NULL here will work SEE: ares_query.c 
             )
+            if status != ARES_SUCCESS:
+                raise AresError(status)
+            
             
         elif _qtype == T_AAAA:
-            ares_query(
+            status = ares_query_dnsrec(
                 self.channel,
                 <char*>view.buf,
-                qclass,
-                T_AAAA,               
-                __callback_query_on_aaaa, # type: ignore
-                <void*>fut
+                <ares_dns_class_t>qclass,
+                ARES_REC_TYPE_AAAA,
+                __callback_dns_rec__aaaa, # type: ignore
+                <void*>fut,
+                NULL, # Passing NULL here will work SEE: ares_query.c 
             )
+            if status != ARES_SUCCESS:
+                raise AresError(status)
         
         elif _qtype == T_CAA:
             ares_query(
@@ -475,14 +484,17 @@ cdef class Channel:
             )
         
         elif _qtype == T_MX:
-            ares_query(
+            status = ares_query_dnsrec(
                 self.channel,
                 <char*>view.buf,
-                qclass,
-                T_MX,
-                __callback_query_on_mx, # type: ignore
-                <void*>fut
+                <ares_dns_class_t>qclass,
+                ARES_REC_TYPE_MX,
+                __callback_dns_rec__mx, # type: ignore
+                <void*>fut,
+                NULL, # Passing NULL here will work SEE: ares_query.c 
             )
+            if status != ARES_SUCCESS:
+                raise AresError(status)
 
         elif _qtype == T_NAPTR:
             ares_query(
@@ -586,24 +598,30 @@ cdef class Channel:
 
 
         if _qtype == T_A:
-            ares_search(
+            status = ares_query_dnsrec(
                 self.channel,
                 <char*>view.buf,
-                qclass,
-                T_A,
-                __callback_query_on_a, # type: ignore
-                <void*>fut
+                <ares_dns_class_t>qclass,
+                ARES_REC_TYPE_A,
+                __callback_dns_rec__a, # type: ignore
+                <void*>fut,
+                NULL, # Passing NULL here will work SEE: ares_query.c 
             )
+            if status != ARES_SUCCESS:
+                raise AresError(status)
             
         elif _qtype == T_AAAA:
-            ares_search(
+            status = ares_query_dnsrec(
                 self.channel,
                 <char*>view.buf,
-                qclass,
-                T_AAAA,               
-                __callback_query_on_aaaa, # type: ignore
-                <void*>fut
+                <ares_dns_class_t>qclass,
+                ARES_REC_TYPE_AAAA,
+                __callback_dns_rec__aaaa, # type: ignore
+                <void*>fut,
+                NULL, # Passing NULL here will work SEE: ares_query.c 
             )
+            if status != ARES_SUCCESS:
+                raise AresError(status)
         
         elif _qtype == T_CAA:
             ares_search(
@@ -626,14 +644,18 @@ cdef class Channel:
             )
         
         elif _qtype == T_MX:
-            ares_search(
+            # TODO: Fix it...
+            status = ares_query_dnsrec(
                 self.channel,
                 <char*>view.buf,
-                qclass,
-                T_MX,
-                __callback_query_on_mx, # type: ignore
-                <void*>fut
+                <ares_dns_class_t>qclass,
+                ARES_REC_TYPE_MX,
+                __callback_dns_rec__mx, # type: ignore
+                <void*>fut,
+                NULL, # Passing NULL here will work SEE: ares_query.c 
             )
+            if status != ARES_SUCCESS:
+                raise AresError(status)
 
         elif _qtype == T_NAPTR:
             ares_search(

--- a/cyares/resulttypes.pyx
+++ b/cyares/resulttypes.pyx
@@ -56,11 +56,11 @@ cdef class ares_query_a_result(AresResult):
 
     @staticmethod
     cdef ares_query_a_result new(const ares_dns_rr_t *rr):
-        cdef bytes buf = PyBytes_FromStringAndSize(NULL, INET_ADDRSTRLEN)
+        cdef char buf[16]
         cdef ares_query_a_result r = ares_query_a_result.__new__(ares_query_a_result)
         cdef const in_addr* addr = ares_dns_rr_get_addr(rr, ARES_RR_A_ADDR)
-        ares_inet_ntop(AF_INET, <void*>addr, PyBytes_AS_STRING(buf), INET6_ADDRSTRLEN)
-        r.host = buf
+        ares_inet_ntop(AF_INET, <void*>addr, buf, INET_ADDRSTRLEN)
+        r.host = PyBytes_FromString(buf)
         r.ttl = rr.ttl
         r._attrs = ("host", "ttl")
         return r
@@ -89,7 +89,7 @@ cdef class ares_query_aaaa_result(AresResult):
     cdef ares_query_aaaa_result new(const ares_dns_rr_t *rr):
         cdef char[46] buf 
         cdef ares_query_aaaa_result r = ares_query_aaaa_result.__new__(ares_query_aaaa_result)
-        cdef const ares_in6_addr* addr = ares_dns_rr_get_addr6(rr, ARES_RR_A_ADDR)
+        cdef const ares_in6_addr* addr = ares_dns_rr_get_addr6(rr, ARES_RR_AAAA_ADDR)
 
         ares_inet_ntop(AF_INET6, <void*>addr, buf, INET6_ADDRSTRLEN)
         r.host = PyBytes_FromString(buf)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

ares_query is being slowly moved to the new dns recursion functions. The reason for acting on this in increments is due to lack of motivation to do the others at the moment but hopefully we will fully migrate over time to the new C-Ares functions that aren't deprecated.

## Are there changes in behavior for the user?

One word of caution, ANY is still broken and does crash and I am working on fixing it soon...

## Is it a substantial burden for the maintainers to support this?

In a way this has been a burden for me to support this going forward mainly given the fact that we need more callbacks to be supplied to make the system run faster than pycares.

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
