### PR TITLE
implement server state callbacks

### DIFF
--- a/cyares/ares.pxd
+++ b/cyares/ares.pxd
@@ -766,3 +766,21 @@ typedef void* (*cyares_arealloc)(void *ptr, size_t size);
         cyares_afree afree,
         cyares_arealloc arealloc
     )
+
+
+    # Server state callbacks added in 0.7.0
+    ctypedef void (*ares_server_state_callback)(
+        const char *server_string ,
+        ares_bool_t success ,
+        int flags ,
+        void *data
+    ) noexcept nogil
+
+    void ares_set_server_state_callback(
+        ares_channel_t *channel,
+        ares_server_state_callback callback,
+        void *user_data
+    )
+    enum: ARES_SERV_STATE_UDP
+    enum: ARES_SERV_STATE_TCP
+

--- a/cyares/channel.pxd
+++ b/cyares/channel.pxd
@@ -31,6 +31,7 @@ cdef class Channel:
         # if checking before wait(...) is required...
         readonly bint event_thread
         SocketHandle socket_handle # if we have one
+        object server_state_handle
 
 
     cpdef void cancel(self) noexcept

--- a/cyares/channel.pyi
+++ b/cyares/channel.pyi
@@ -115,6 +115,10 @@ AI_IDN_USE_STD3_ASCII_RULES: int  # IDN_USE_STD3_ASCII_RULES
 AI_CANONIDN: int  # CANONIDN
 AI_MASK: int  # MASK
 
+SERVER_STATE_TCP: int # Sever state
+SERVER_STATE_UDP: int # Server state
+
+
 class Channel:
     event_thread: bool
     """Used for checking if event-thread is in use before using wait(...)
@@ -326,6 +330,16 @@ class Channel:
         :rtype: int
         :raises ValueError: if value is attempted to be set
         """
+
+    def set_server_state_callback(self, callback: Callable[[str, bool, int], None]) -> None:
+        """
+        sets a server state callback for monitoring successful or unsuccessful dns queries.
+
+        :param callback: a callback to invoke
+        :raises TypeError: if callback isn't callable
+        """
+
+    
 
 def cyares_threadsafety() -> bool:
     """

--- a/cyares/channel.pyx
+++ b/cyares/channel.pyx
@@ -1,11 +1,12 @@
 # cython: embed_signature=True
 cimport cython
-from cpython.bytes cimport PyBytes_FromString, PyBytes_FromStringAndSize
+from cpython.bool cimport PyBool_FromLong
+from cpython.bytes cimport PyBytes_FromString
 from cpython.exc cimport PyErr_NoMemory, PyErr_SetObject
 from cpython.mem cimport (PyMem_Free, PyMem_Malloc, PyMem_RawFree,
                           PyMem_RawMalloc, PyMem_RawRealloc)
 from cpython.ref cimport Py_DECREF, Py_INCREF
-from cpython.unicode cimport PyUnicode_Check, PyUnicode_GetLength
+from cpython.unicode cimport PyUnicode_Check, PyUnicode_GetLength, PyUnicode_FromString
 from libc.math cimport floor, fmod
 
 from .ares cimport *
@@ -182,6 +183,31 @@ QUERY_CLASS_HS = ARES_CLASS_HESOID
 QUERY_CLASS_NONE = ARES_CLASS_NONE
 QUERY_CLASS_ANY = ARES_CLASS_ANY
 
+cpdef enum:
+    SERVER_STATE_TCP = ARES_SERV_STATE_TCP
+
+cpdef enum:
+    SERVER_STATE_UDP = ARES_SERV_STATE_UDP
+
+
+cdef void __server_state_cb(
+    const char* server,
+    ares_bool_t success,
+    int flags,
+    void* data
+) noexcept nogil:
+    if data == NULL:
+        return
+    with gil:
+        cb = <object>data
+        try:
+            cb(
+                PyUnicode_FromString(server), 
+                PyBool_FromLong(success == 1), 
+                flags
+            )
+        except BaseException as e:
+            print(e)
 
 # used for helping establish and cleanup the dns_recurion pointer on callback
 # This is not meant to be used in public code outside of channel.pyx
@@ -397,7 +423,8 @@ cdef class Channel:
         finally:
             if strs != NULL:
                 PyMem_Free(strs)
-        
+
+        self.server_state_handle = None
     
     # TODO (Vizonex): Separate Server into a Seperate class and incorperate support for yarl
     # if you want to learn more about ares_get_servers_csv This should explain why
@@ -1028,7 +1055,20 @@ cdef class Channel:
     def running_queries(self, object ignore):
         raise ValueError("running_queries is an immutable property")
 
-
+    def set_server_state_callback(self, object callback):
+        """
+        sets a server state callback for monitoring successful or unsuccessful dns queries.
+        
+        :param callback: a callback to invoke
+        :raises TypeError: if callback isn't callable
+        """
+        if not callable(callback):
+            raise TypeError("callback must be callable")
+        self.server_state_handle = callback
+        with nogil:
+            ares_set_server_state_callback(self.channel, __server_state_cb, <void*>callback)
+        
+        
 
 
 def cyares_threadsafety():

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -321,6 +321,23 @@ def test_close_from_different_thread_safe():
     # Should complete without errors
     assert close_complete.is_set()
 
+def test_channel_server_state_cb() -> None:
+    channel = Channel(servers=["8.8.8.8"],event_thread=True)
+
+    def on_server_state(server: str, success: bool, flags:int):
+        assert server == "8.8.8.8:53"
+        assert isinstance(success, bool)
+        assert isinstance(flags, int)
+
+
+    def noop(*args):
+        return
+    channel.set_server_state_callback(on_server_state)
+    channel.query("www.google.com", 'A', callback=noop)
+    channel.wait()
+
+
+
 
 # Since we do not have direct access to things anymore since the removal
 # of getsock we have to try something different...


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

These changes implement server state callbacks similar to something I am trying to add in pycares also.

## Are there changes in behavior for the user?

Just new features nothing new has really changed other than that.

## Is it a substantial burden for the maintainers to support this?

Nope. It's easy to add in and only requires a single test to ensure correctness even if that test throws an exception were just needing to know what `server_state_cb` is doing.
## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
