### PR TITLE
implement ares-process-write-callbacks

### DIFF
--- a/cyares/aio.py
+++ b/cyares/aio.py
@@ -22,11 +22,12 @@ from collections.abc import Iterable, Sequence
 from logging import getLogger
 from typing import Any, TypeVar
 
+from deprecated_subclass import deprecated_subclass
+
 from .channel import (
     Channel,
     cyares_threadsafety,
 )  # type: ignore  # noqa: F403
-from deprecated_subclass import deprecated_subclass
 from .exception import AresError  # type: ignore
 from .handles import CancelledError, InvalidStateError
 from .handles import Future as cc_Future  # type: ignore
@@ -279,10 +280,17 @@ class DNSResolver:
 
         if servers:
             self.nameservers = servers
+        if not self._event_thread:
+            self._channel.set_pending_write_callback(
+                self._queue_pending_writes
+            )
         self._read_fds: set[int] = set()
         self._write_fds: set[int] = set()
         self._timer: asyncio.TimerHandle | None = None
         self._closed = False
+
+    def _queue_pending_writes(self):
+        self.loop.call_soon(self._channel.process_pending_write)
 
     def _raise_if_windows_proctor(self):
         if sys.platform == "win32" and type(self.loop) is asyncio.ProactorEventLoop:
@@ -376,7 +384,7 @@ class DNSResolver:
                 self._write_fds.discard(fd)
                 self.loop.remove_writer(fd)
 
-            if not self._read_fds and not self._write_fds and self._timer is not None:
+            if not (self._read_fds and self._write_fds) and (self._timer is not None):
                 self._timer.cancel()
                 self._timer = None
 

--- a/cyares/anyio.py
+++ b/cyares/anyio.py
@@ -16,9 +16,9 @@ from anyio import (
 )
 from anyio.abc import AsyncBackend, TaskGroup, TaskStatus
 from anyio.lowlevel import current_token, get_async_backend
+from deprecated_subclass import deprecated_subclass
 
 from .channel import Channel
-from deprecated_subclass import deprecated_subclass
 from .handles import Future as _Future
 from .resulttypes import AddrInfoResult, DNSResult, HostResult, NameInfoResult
 from .typedefs import (
@@ -229,6 +229,15 @@ class DNSResolver:
         self._timer = None
         self._token = current_token()
         self._closed = False
+
+        if not self._channel.event_thread:
+            self._channel.set_pending_write_callback(self.__process_pending_tcp_writes)
+
+    async def __process_tcp_writes(self):
+        self._channel.process_pending_write()
+
+    def __process_pending_tcp_writes(self):
+        self._group.start_soon(self.__process_tcp_writes)
 
     async def __aenter__(self):
         await self._group.__aenter__()

--- a/cyares/ares.pxd
+++ b/cyares/ares.pxd
@@ -784,3 +784,17 @@ typedef void* (*cyares_arealloc)(void *ptr, size_t size);
     enum: ARES_SERV_STATE_UDP
     enum: ARES_SERV_STATE_TCP
 
+    # added in 0.7.0
+    ctypedef void (*ares_pending_write_cb)(void *data) noexcept nogil
+
+    void ares_set_pending_write_cb(
+      ares_channel_t        *channel,
+      ares_pending_write_cb  callback,
+      void                  *user_data)
+
+    void ares_process_pending_write(ares_channel_t *channel)
+
+
+
+
+

--- a/cyares/channel.pxd
+++ b/cyares/channel.pxd
@@ -32,6 +32,7 @@ cdef class Channel:
         readonly bint event_thread
         SocketHandle socket_handle # if we have one
         object server_state_handle
+        object pending_write_handle
 
 
     cpdef void cancel(self) noexcept

--- a/cyares/channel.pyi
+++ b/cyares/channel.pyi
@@ -339,7 +339,27 @@ class Channel:
         :raises TypeError: if callback isn't callable
         """
 
-    
+    def set_pending_write_callback(self, callback:Callable[[], None]):
+        """
+        sets a callback function function when there is pending
+        TCP data to be written. It helps with notifiying about
+        large sums of data that may need to be written in one
+        big buffer.
+
+        :param callback: the callback to invoke
+        :raises TypeError: if callback is not callable
+        :raises RuntimeError: if event-thread is
+            being used which isn't compatable.
+        """
+
+    def process_pending_write(self) -> None:
+        """
+        should be tied to using set_pending_write_callback.
+        This function should be called on queue of the eventloop
+        when TCP data needs sending in large chunks.
+
+        :raises RuntimeError: if the channel uses an event-thread.
+        """
 
 def cyares_threadsafety() -> bool:
     """

--- a/cyares/channel.pyx
+++ b/cyares/channel.pyx
@@ -209,6 +209,16 @@ cdef void __server_state_cb(
         except BaseException as e:
             print(e)
 
+cdef void __pending_write_cb(void * data) noexcept nogil:
+    if data == NULL:
+        return
+    with gil:
+        cb = <object>data
+        try:
+            cb()
+        except BaseException as e:
+            print(e)
+
 # used for helping establish and cleanup the dns_recurion pointer on callback
 # This is not meant to be used in public code outside of channel.pyx
 # copy and paste this code if you need it elsewhere... 
@@ -1067,8 +1077,46 @@ cdef class Channel:
         self.server_state_handle = callback
         with nogil:
             ares_set_server_state_callback(self.channel, __server_state_cb, <void*>callback)
-        
-        
+    
+    def set_pending_write_callback(self, object callback):
+        """
+        sets a callback function function when there is pending 
+        TCP data to be written. It helps with notifiying about 
+        large sums of data that may need to be written in one 
+        big buffer.
+
+        :param callback: the callback to invoke
+        :raises TypeError: if callback is not callable
+        :raises RuntimeError: if event-thread is 
+            being used which isn't compatable.
+        """
+        if self.event_thread:
+            raise RuntimeError(
+                "pending write callbacks cannot be used"
+                " when an event thread is enabled."
+            )
+        if not callable(callback):
+            raise TypeError("callback must be callable")
+        self.pending_write_handle = callback
+        with nogil:
+            ares_set_pending_write_cb(self.channel, __pending_write_cb, <void*>callback)
+    
+    def process_pending_write(self) -> None:
+        """
+        should be tied to using set_pending_write_callback.
+        This function should be called on queue of the eventloop
+        when TCP data needs sending in large chunks.
+
+        :raises RuntimeError: if the channel uses an event-thread.
+        """
+        if self.event_thread:
+            raise RuntimeError(
+                    "processing pending write callbacks cannot be used"
+                    " when an event thread is enabled."
+                )
+        with nogil:
+            ares_process_pending_write(self.channel)
+
 
 
 def cyares_threadsafety():

--- a/cyares/trio.py
+++ b/cyares/trio.py
@@ -15,10 +15,10 @@ from types import GenericAlias
 from typing import Generic
 
 import trio
+from deprecated_subclass import deprecated_subclass
 from trio.lowlevel import current_clock, current_trio_token
 
 from .channel import Channel
-from deprecated_subclass import deprecated_subclass
 from .handles import Future as ccFuture
 from .resulttypes import AddrInfoResult, DNSResult, HostResult, NameInfoResult
 from .typedefs import (
@@ -195,6 +195,17 @@ class DNSResolver:
         self._timer = None
         self._token = current_trio_token()
         self._closed = False
+
+        # This is a TCP Performance optimization
+        if not self._channel.event_thread:
+            self._channel.set_pending_write_callback(self.__process_pending_tcp_writes)
+
+    async def __process_tcp_writes(self):
+        self._channel.process_pending_write()
+
+    def __process_pending_tcp_writes(self):
+        self._nursery.start_soon(self.__process_tcp_writes)
+
 
     async def __aenter__(self):
         self._nursery = await self._manager.__aenter__()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This change adds in another part of c-ares that adds more callback options to use as part of a TCP Optimization. (I would be curious if the maintainers of pycares want these additional features also) for now I've left to my side to play around with it first.
There is another final PR coming before I release the __0.7.0__ update and that is going to be processing many read and write fds which should be a very good performance optimization for selectors, epolls and the pywepoll library.

## Are there changes in behavior for the user?

<!-- Outline any notable behavior for the end users. -->

## Is it a substantial burden for the maintainers to support this?

Nope. I like this change, more options for users to pick and choose from which is all I could ask for.

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
