### PR TITLE
test rsloop & wepoll in aio and anyio tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ anyio = ["anyio>=4.12.1"]
 
 [tool.cibuildwheel]
 build-frontend = "build"
-enable = ["cpython-freethreading"]
+# enable = ["cpython-freethreading"]
 
 
 [build-system]

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,3 +12,5 @@ dnslib==0.9.26
 pytest-codspeed==5.0.3
 pycares==5.0.1
 trio>=0.30.0
+wepoll==0.5.1; platform_system == "Windows"
+rsloop==0.1.21

--- a/tests/test_aio_cyares.py
+++ b/tests/test_aio_cyares.py
@@ -1,36 +1,49 @@
 import asyncio
 import ipaddress
 import sys
+from importlib.util import find_spec
 
 import pytest
 
 from cyares.aio import DNSResolver
 from cyares.error import AresError
 
-uvloop = pytest.importorskip("winloop" if sys.platform == "win32" else "uvloop")
 
-PARAMS = [
-    pytest.param(
-        ("asyncio", {"loop_factory": uvloop.new_event_loop}), id="asyncio[uvloop]"
-    ),
-    pytest.param(("asyncio", {"use_uvloop": False}), id="asyncio"),
-]
+def has_module(library: str):
+    "Finds out if library exists without executing any code for the library."
+    return find_spec(library) is not None
 
-if sys.platform == "win32":
+
+PARAMS = [pytest.param(("asyncio", {"use_uvloop": False}), id="asyncio")]
+
+# NOTE: Extensions are optional now...
+if has_module("winloop" if sys.platform == "win32" else "uvloop"):
+    PARAMS.append(pytest.param(("asyncio", {"use_uvloop": True}), id="asyncio[uvloop]"))
+
+if has_module("rsloop"):
+    import rsloop
+
     PARAMS.append(
         pytest.param(
-            ("asyncio", {"loop_factory": asyncio.SelectorEventLoop}),
-            id="asyncio[win32+selector]",
+            ("asyncio", {"loop_factory": rsloop.new_event_loop}), id="asyncio[rsloop]"
         )
     )
+if sys.platform == "win32":
+    if has_module("wepoll"):
+        import wepoll
+
+        PARAMS.append(
+            pytest.param(
+                ("asyncio", {"loop_factory": wepoll.new_event_loop}),
+                id="asyncio[wepoll]",
+            )
+        )
 
 
 @pytest.fixture(params=PARAMS)
 def anyio_backend(request: pytest.FixtureRequest):
     return request.param
 
-
-# TODO: Migrate this section over to anyio in 0.1.6 or sooner...
 
 
 # TODO: Parametize turning certain event_threads on and off in a future cyares update.

--- a/tests/test_anyio.py
+++ b/tests/test_anyio.py
@@ -23,7 +23,7 @@ if sys.platform == "win32":
     )
 else:
     PARAMS.append(
-        pytest.param("asyncio", {"loop_factory": asyncio.new_event_loop}, id="asyncio")
+        pytest.param("asyncio", {"use_uvloop": False}, id="asyncio")
     )
 
 # NOTE: Extensions are optional now...

--- a/tests/test_anyio.py
+++ b/tests/test_anyio.py
@@ -22,7 +22,9 @@ if sys.platform == "win32":
         )
     )
 else:
-    PARAMS.append(pytest.param("asyncio", {}, id="asyncio"))
+    PARAMS.append(
+        pytest.param("asyncio", {"loop_factory": asyncio.new_event_loop}, id="asyncio")
+    )
 
 # NOTE: Extensions are optional now...
 if has_module("winloop" if sys.platform == "win32" else "uvloop"):
@@ -48,9 +50,8 @@ if sys.platform == "win32":
         )
 
 if has_module("trio"):
-    PARAMS.append(
-        pytest.param(("trio", {}), id="trio")
-    )
+    PARAMS.append(pytest.param(("trio", {}), id="trio"))
+
 
 # use all backends...
 @pytest.fixture(params=PARAMS)

--- a/tests/test_anyio.py
+++ b/tests/test_anyio.py
@@ -1,32 +1,56 @@
 import asyncio
 import ipaddress
 import sys
+from importlib.util import find_spec
 
-import anyio as anyio
 import pytest
 
 from cyares.anyio import DNSResolver
 from cyares.error import AresError
 
-uvloop = pytest.importorskip("winloop" if sys.platform == "win32" else "uvloop")
 
-# TODO: (Vizonex) test rloop support on linux and Apple Operating systems
-PARAMS: list[str] = [
-    pytest.param(
-        ("asyncio", {"loop_factory": uvloop.new_event_loop}), id="asyncio[uvloop]"
-    ),
-    pytest.param(("asyncio", {"use_uvloop": False}), id="asyncio"),
-    pytest.param("trio"),
-]
+def has_module(library: str):
+    "Finds out if library exists without executing any code for the library."
+    return find_spec(library) is not None
 
+
+PARAMS = []
 if sys.platform == "win32":
     PARAMS.append(
         pytest.param(
-            ("asyncio", {"loop_factory": asyncio.SelectorEventLoop}),
-            id="asyncio[win32+selector]",
+            ("asyncio", {"loop_factory": asyncio.SelectorEventLoop}), id="asyncio"
         )
     )
+else:
+    PARAMS.append(pytest.param("asyncio", {}, id="asyncio"))
 
+# NOTE: Extensions are optional now...
+if has_module("winloop" if sys.platform == "win32" else "uvloop"):
+    PARAMS.append(pytest.param(("asyncio", {"use_uvloop": True}), id="asyncio[uvloop]"))
+
+if has_module("rsloop"):
+    import rsloop
+
+    PARAMS.append(
+        pytest.param(
+            ("asyncio", {"loop_factory": rsloop.new_event_loop}), id="asyncio[rsloop]"
+        )
+    )
+if sys.platform == "win32":
+    if has_module("wepoll"):
+        import wepoll
+
+        PARAMS.append(
+            pytest.param(
+                ("asyncio", {"loop_factory": wepoll.new_event_loop}),
+                id="asyncio[wepoll]",
+            )
+        )
+
+if has_module("trio"):
+    PARAMS.append(
+        pytest.param(("trio", {}), id="trio")
+    )
 
 # use all backends...
 @pytest.fixture(params=PARAMS)

--- a/tests/test_anyio.py
+++ b/tests/test_anyio.py
@@ -23,7 +23,7 @@ if sys.platform == "win32":
     )
 else:
     PARAMS.append(
-        pytest.param("asyncio", {"use_uvloop": False}, id="asyncio")
+        pytest.param(("asyncio", {"use_uvloop": False}), id="asyncio")
     )
 
 # NOTE: Extensions are optional now...


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

These are 2 more possible EventLoop candidates to add to the current test-suite. __rsloop__ in particular one that I have interest in due to it's capabilities along with windows support right out of the box. wepoll has an selector eventloop of it's own for windows so I added to the mix also. We also test cyares vice versa on it's side so that wepoll is stress tested as much as possible.

## Are there changes in behavior for the user?

<!-- Outline any notable behavior for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
